### PR TITLE
Remove class_name from Rat example

### DIFF
--- a/addons/curved_lines_2d/examples/rat/rat.gd
+++ b/addons/curved_lines_2d/examples/rat/rat.gd
@@ -1,4 +1,3 @@
-class_name Rat
 extends CharacterBody2D
 
 


### PR DESCRIPTION
Otherwise everyone that install the plugin will have the class name "Rat" in use.