### PR TITLE
Make arc_settings_popup_panel not visible at start

### DIFF
--- a/addons/curved_lines_2d/arc_settings_popup_panel.gd
+++ b/addons/curved_lines_2d/arc_settings_popup_panel.gd
@@ -12,6 +12,7 @@ var _dragging := false
 var _drag_start := Vector2.ZERO
 
 func _enter_tree() -> void:
+	visible = false
 	rx_input = _mk_input()
 	ry_input = _mk_input()
 	rotation_input = _mk_input(1.0)


### PR DESCRIPTION
I'm not sure here but I think that Godot always make popups visible when you open in the editor.  

https://www.youtube.com/watch?v=rAhRDdiGffo  

If I open ArcSettingsPopupPanel, set invisible and close the scene, it will be invisible... Until I open the scene again, then Godot make it visible and I need to change to invisible before close the scene.  

Making visible through code would let anyone edit the scene without have to remember this little detail.  

Note: I inserted in `_enter_tree()` but I don't know if is the best place.  