### PR TITLE
Replace some uses of `find_child()` by unique names

### DIFF
--- a/addons/curved_lines_2d/arc_settings_popup_panel.gd
+++ b/addons/curved_lines_2d/arc_settings_popup_panel.gd
@@ -4,8 +4,6 @@ extends PopupPanel
 var rx_input : EditorSpinSlider
 var ry_input : EditorSpinSlider
 var rotation_input : EditorSpinSlider
-var large_arc_checkbox : CheckBox
-var sweep_checkbox : CheckBox
 var _arc_under_edit : ScalableArc
 
 var _dragging := false
@@ -16,11 +14,9 @@ func _enter_tree() -> void:
 	rx_input = _mk_input()
 	ry_input = _mk_input()
 	rotation_input = _mk_input(1.0)
-	large_arc_checkbox = find_child("LargeArcCheckBox")
-	sweep_checkbox = find_child("SweepCheckBox")
-	find_child("RxInputContainer").add_child(rx_input)
-	find_child("RyInputContainer").add_child(ry_input)
-	find_child("RotationInputContainer").add_child(rotation_input)
+	%RxInputContainer.add_child(rx_input)
+	%RyInputContainer.add_child(ry_input)
+	%RotationInputContainer.add_child(rotation_input)
 	if not rx_input.value_changed.is_connected(_on_radius_changed):
 		rx_input.value_changed.connect(_on_radius_changed)
 	if not ry_input.value_changed.is_connected(_on_radius_changed):
@@ -69,8 +65,8 @@ func popup_with_value(arc : ScalableArc):
 	rx_input.set_value_no_signal(arc.radius.x)
 	ry_input.set_value_no_signal(arc.radius.y)
 	rotation_input.set_value_no_signal(arc.rotation_deg)
-	large_arc_checkbox.set_pressed_no_signal(arc.large_arc_flag)
-	sweep_checkbox.set_pressed_no_signal(arc.sweep_flag)
+	%LargeArcCheckBox.set_pressed_no_signal(arc.large_arc_flag)
+	%SweepCheckBox.set_pressed_no_signal(arc.sweep_flag)
 	popup_centered()
 
 

--- a/addons/curved_lines_2d/arc_settings_popup_panel.tscn
+++ b/addons/curved_lines_2d/arc_settings_popup_panel.tscn
@@ -25,7 +25,6 @@ bg_color = Color(0.0588235, 0.0588235, 0.0588235, 1)
 
 [node name="ArcSettingsPopupPanel" type="PopupPanel"]
 size = Vector2i(250, 251)
-visible = true
 script = ExtResource("1_3bjn8")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
@@ -84,6 +83,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="RxInputContainer" type="PanelContainer" parent="VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
@@ -106,6 +106,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="RyInputContainer" type="PanelContainer" parent="VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer2/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
@@ -122,6 +123,7 @@ text = "Rotation"
 label_settings = SubResource("LabelSettings_3bjn8")
 
 [node name="RotationInputContainer" type="PanelContainer" parent="VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -146,6 +148,7 @@ size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_1vtg0")
 
 [node name="LargeArcCheckBox" type="CheckBox" parent="VBoxContainer/HBoxContainer3/Container"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "On"
 
@@ -168,6 +171,7 @@ size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_1vtg0")
 
 [node name="SweepCheckBox" type="CheckBox" parent="VBoxContainer/HBoxContainer4/Container"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "On"
 

--- a/addons/curved_lines_2d/assign_collision_inspector_form.gd
+++ b/addons/curved_lines_2d/assign_collision_inspector_form.gd
@@ -4,12 +4,10 @@ extends Control
 class_name AssignCollisionInspectorForm
 
 var scalable_vector_shape_2d : ScalableVectorShape2D
-var select_button : Button
 
 func _enter_tree() -> void:
 	if not is_instance_valid(scalable_vector_shape_2d):
 		return
-	select_button = find_child("GotoCollisionButton")
 	if 'assigned_node_changed' in scalable_vector_shape_2d:
 		scalable_vector_shape_2d.assigned_node_changed.connect(_on_svs_assignment_changed)
 	_on_svs_assignment_changed()
@@ -17,8 +15,8 @@ func _enter_tree() -> void:
 
 func _on_svs_assignment_changed() -> void:
 	if is_instance_valid(scalable_vector_shape_2d.collision_polygon):
-		select_button.get_parent().show()
-		select_button.disabled = false
+		%GotoCollisionButton.get_parent().show()
+		%GotoCollisionButton.disabled = false
 	else:
 		hide()
 
@@ -29,4 +27,3 @@ func _on_goto_collision_button_pressed() -> void:
 	if not is_instance_valid(scalable_vector_shape_2d.collision_polygon):
 		return
 	EditorInterface.call_deferred('edit_node', scalable_vector_shape_2d.collision_polygon)
-

--- a/addons/curved_lines_2d/assign_collision_inspector_form.tscn
+++ b/addons/curved_lines_2d/assign_collision_inspector_form.tscn
@@ -28,6 +28,7 @@ mouse_filter = 0
 text = "⚠️ CollisionPolygon2D*"
 
 [node name="GotoCollisionButton" type="Button" parent="ButtonContainer2"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 2
 tooltip_text = "Click on this button to select the CollisionPolygon2D node that is assigned to this shape  in the Scene Tree.

--- a/addons/curved_lines_2d/assign_collision_object_inspector_form.gd
+++ b/addons/curved_lines_2d/assign_collision_object_inspector_form.gd
@@ -15,12 +15,12 @@ func _enter_tree() -> void:
 
 func _on_svs_assignment_changed() -> void:
 	if is_instance_valid(scalable_vector_shape_2d.collision_object):
-		find_child("GoToCollisionObjectButton").show()
-		find_child("CollisionObjectTypeOptionButton").hide()
+		%GoToCollisionObjectButton.show()
+		%CollisionObjectTypeOptionButton.hide()
 	else:
-		find_child("GoToCollisionObjectButton").hide()
-		find_child("CollisionObjectTypeOptionButton").show()
-		(find_child("CollisionObjectTypeOptionButton") as OptionButton).select(0)
+		%GoToCollisionObjectButton.hide()
+		%CollisionObjectTypeOptionButton.show()
+		%CollisionObjectTypeOptionButton.select(0)
 
 func _on_collision_object_type_option_button_type_selected(obj_type: ScalableVectorShape2D.CollisionObjectType) -> void:
 	if not is_instance_valid(scalable_vector_shape_2d):
@@ -63,4 +63,3 @@ func _on_go_to_collision_object_button_pressed() -> void:
 	if not is_instance_valid(scalable_vector_shape_2d.collision_object):
 		return
 	EditorInterface.call_deferred('edit_node', scalable_vector_shape_2d.collision_object)
-

--- a/addons/curved_lines_2d/assign_collision_object_inspector_form.tscn
+++ b/addons/curved_lines_2d/assign_collision_object_inspector_form.tscn
@@ -26,10 +26,12 @@ mouse_filter = 0
 text = "Collision Object* "
 
 [node name="CollisionObjectTypeOptionButton" parent="HBoxContainer" instance=ExtResource("2_ks3po")]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="GoToCollisionObjectButton" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3

--- a/addons/curved_lines_2d/assign_fill_inspector_form.gd
+++ b/addons/curved_lines_2d/assign_fill_inspector_form.gd
@@ -4,25 +4,11 @@ extends KeyframeButtonCapableInspectorFormBase
 class_name AssignFillInspectorForm
 
 var scalable_vector_shape_2d : ScalableVectorShape2D
-var create_button : Button
-var select_button : Button
-var color_button : ColorPickerButton
 
-var remove_gradient_toggle_button : Button
-var linear_gradient_toggle_button : Button
-var radial_gradient_toggle_button : Button
-var other_texture_toggle_button : Button
 
 func _enter_tree() -> void:
 	if not is_instance_valid(scalable_vector_shape_2d):
 		return
-	create_button = find_child("CreateFillButton")
-	select_button = find_child("GotoPolygon2DButton")
-	color_button = find_child("ColorPickerButton")
-	remove_gradient_toggle_button = find_child("RemoveGradientToggleButton")
-	linear_gradient_toggle_button = find_child("LinearGradientToggleButton")
-	radial_gradient_toggle_button = find_child("RadialGradientToggleButton")
-	other_texture_toggle_button = find_child("OtherTextureToggleButton")
 	if 'assigned_node_changed' in scalable_vector_shape_2d:
 		scalable_vector_shape_2d.assigned_node_changed.connect(_on_svs_assignment_changed)
 	_on_svs_assignment_changed()
@@ -30,46 +16,46 @@ func _enter_tree() -> void:
 
 
 func _on_key_frame_capabilities_changed():
-	find_child("AddFillKeyFrameButton").visible = _is_key_frame_capable()
-	find_child("BatchInsertGradientKeyFrameButton").visible = _is_key_frame_capable()
+	%AddFillKeyFrameButton.visible = _is_key_frame_capable()
+	%BatchInsertGradientKeyFrameButton.visible = _is_key_frame_capable()
 
 
 func _on_svs_assignment_changed() -> void:
 	if is_instance_valid(scalable_vector_shape_2d.polygon):
-		create_button.get_parent().hide()
-		select_button.get_parent().show()
-		find_child("GradientFieldContainer").show()
-		find_child("GradientStopColorButtonContainer").show()
-		create_button.disabled = true
-		select_button.disabled = false
-		color_button.color = scalable_vector_shape_2d.polygon.color
-		radial_gradient_toggle_button.disabled = false
-		linear_gradient_toggle_button.disabled = false
-		remove_gradient_toggle_button.disabled = false
+		%CreateFillButton.get_parent().hide()
+		%GotoPolygon2DButton.get_parent().show()
+		%GradientFieldContainer.show()
+		%GradientStopColorButtonContainer.show()
+		%CreateFillButton.disabled = true
+		%GotoPolygon2DButton.disabled = false
+		%ColorPickerButton.color = scalable_vector_shape_2d.polygon.color
+		%RadialGradientToggleButton.disabled = false
+		%LinearGradientToggleButton.disabled = false
+		%RemoveGradientToggleButton.disabled = false
 		if scalable_vector_shape_2d.polygon.texture is GradientTexture2D:
 			if scalable_vector_shape_2d.polygon.texture.fill == GradientTexture2D.FILL_RADIAL:
-				radial_gradient_toggle_button.button_pressed = true
+				%RadialGradientToggleButton.button_pressed = true
 			else:
-				linear_gradient_toggle_button.button_pressed = true
+				%LinearGradientToggleButton.button_pressed = true
 			_set_gradient_stop_color_buttons()
 		elif scalable_vector_shape_2d.polygon.texture:
-			other_texture_toggle_button.button_pressed = true
-			find_child("GradientStopColorButtonContainer").hide()
+			%OtherTextureToggleButton.button_pressed = true
+			%GradientStopColorButtonContainer.hide()
 		else:
-			remove_gradient_toggle_button.button_pressed = true
-			find_child("GradientStopColorButtonContainer").hide()
+			%RemoveGradientToggleButton.button_pressed = true
+			%GradientStopColorButtonContainer.hide()
 	else:
-		create_button.get_parent().show()
-		select_button.get_parent().hide()
-		find_child("GradientFieldContainer").hide()
-		find_child("GradientStopColorButtonContainer").hide()
-		create_button.disabled = false
-		select_button.disabled = true
-		color_button.color = CurvedLines2D._get_default_fill_color()
-		radial_gradient_toggle_button.disabled = true
-		linear_gradient_toggle_button.disabled = true
-		remove_gradient_toggle_button.disabled = true
-		remove_gradient_toggle_button.button_pressed = true
+		%CreateFillButton.get_parent().show()
+		%GotoPolygon2DButton.get_parent().hide()
+		%GradientFieldContainer.hide()
+		%GradientStopColorButtonContainer.hide()
+		%CreateFillButton.disabled = false
+		%GotoPolygon2DButton.disabled = true
+		%ColorPickerButton.color = CurvedLines2D._get_default_fill_color()
+		%RadialGradientToggleButton.disabled = true
+		%LinearGradientToggleButton.disabled = true
+		%RemoveGradientToggleButton.disabled = true
+		%RemoveGradientToggleButton.button_pressed = true
 
 
 func _on_color_picker_button_color_changed(color: Color) -> void:
@@ -95,7 +81,7 @@ func _on_create_fill_button_pressed():
 	var polygon_2d := Polygon2D.new()
 	var root := EditorInterface.get_edited_scene_root()
 	var undo_redo = EditorInterface.get_editor_undo_redo()
-	polygon_2d.color = color_button.color
+	polygon_2d.color = %ColorPickerButton.color
 	undo_redo.create_action("Add Polygon2D to %s " % str(scalable_vector_shape_2d))
 	undo_redo.add_do_method(scalable_vector_shape_2d, 'add_child', polygon_2d, true)
 	undo_redo.add_do_method(polygon_2d, 'set_owner', root)
@@ -155,18 +141,17 @@ func _set_gradient_stop_color_buttons() -> void:
 	if not scalable_vector_shape_2d.polygon.texture is GradientTexture2D:
 		return
 
-	var container := find_child("StopColorButtonsContainer")
-	for b in container.get_children():
+	for b in %StopColorButtonsContainer.get_children():
 		b.queue_free()
 
 	for idx in range(scalable_vector_shape_2d.polygon.texture.gradient.colors.size()):
 		var color : Color = scalable_vector_shape_2d.polygon.texture.gradient.colors[idx]
 		var new_button := ColorPickerButton.new()
 		new_button.color = color
-		container.add_child(new_button)
 		new_button.color_changed.connect(func(c): _update_stop_color(idx, c))
 		new_button.toggled.connect(func(toggled_on): _handle_stop_color_undo_redo_action(idx, new_button, toggled_on))
 		new_button.custom_minimum_size = Vector2(40, 40)
+		%StopColorButtonsContainer.add_child(new_button)
 
 
 func _on_linear_gradient_toggle_button_button_down() -> void:
@@ -216,7 +201,7 @@ static func _initialize_gradient(box : Rect2) -> GradientTexture2D:
 func _on_add_fill_key_frame_button_pressed() -> void:
 	if is_instance_valid(scalable_vector_shape_2d.polygon):
 		add_key_frame(
-			scalable_vector_shape_2d.polygon, "color", color_button.color
+			scalable_vector_shape_2d.polygon, "color", %ColorPickerButton.color
 		)
 
 
@@ -258,5 +243,5 @@ func _on_color_picker_button_toggled(toggled_on: bool) -> void:
 		undo_redo.create_action("Adjust Polygon2D color for %s" % str(scalable_vector_shape_2d))
 		undo_redo.add_undo_property(scalable_vector_shape_2d.polygon, 'color', scalable_vector_shape_2d.polygon.color)
 	else:
-		undo_redo.add_do_property(scalable_vector_shape_2d.polygon, 'color', color_button.color)
+		undo_redo.add_do_property(scalable_vector_shape_2d.polygon, 'color', %ColorPickerButton.color)
 		undo_redo.commit_action(false)

--- a/addons/curved_lines_2d/assign_fill_inspector_form.tscn
+++ b/addons/curved_lines_2d/assign_fill_inspector_form.tscn
@@ -55,6 +55,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="ColorPickerButton" type="ColorPickerButton" parent="FillColorFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "This will set the color of the assigned Polygon2D."
@@ -63,11 +64,13 @@ text = "Fill"
 color = Color(1, 1, 1, 1)
 
 [node name="AddFillKeyFrameButton" type="Button" parent="FillColorFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Add key frame for Polygon2D's color property"
 icon = ExtResource("3_d26vq")
 
 [node name="GradientFieldContainer" type="HBoxContainer" parent="."]
+unique_name_in_owner = true
 layout_mode = 2
 
 [node name="Label" type="Label" parent="GradientFieldContainer"]
@@ -86,6 +89,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="RemoveGradientToggleButton" type="Button" parent="GradientFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -103,6 +107,7 @@ button_group = SubResource("ButtonGroup_6uned")
 icon = SubResource("AtlasTexture_7smxo")
 
 [node name="LinearGradientToggleButton" type="Button" parent="GradientFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -119,6 +124,7 @@ button_group = SubResource("ButtonGroup_6uned")
 icon = SubResource("AtlasTexture_j40rh")
 
 [node name="RadialGradientToggleButton" type="Button" parent="GradientFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -135,6 +141,7 @@ button_group = SubResource("ButtonGroup_6uned")
 icon = SubResource("AtlasTexture_7rdpo")
 
 [node name="OtherTextureToggleButton" type="Button" parent="GradientFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -152,6 +159,7 @@ button_group = SubResource("ButtonGroup_6uned")
 icon = SubResource("AtlasTexture_alhox")
 
 [node name="GradientStopColorButtonContainer" type="HBoxContainer" parent="."]
+unique_name_in_owner = true
 layout_mode = 2
 
 [node name="Label" type="Label" parent="GradientStopColorButtonContainer"]
@@ -171,11 +179,13 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="StopColorButtonsContainer" type="HFlowContainer" parent="GradientStopColorButtonContainer/HBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="BatchInsertGradientKeyFrameButton" type="Button" parent="GradientStopColorButtonContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
@@ -200,6 +210,7 @@ mouse_filter = 0
 text = "Add Fill*"
 
 [node name="CreateFillButton" type="Button" parent="ButtonContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 2
 tooltip_text = "This will create a new Polygon2D node and assign it to the polygon property of this ScalableVectorScape2D."
@@ -223,6 +234,7 @@ mouse_filter = 0
 text = "Edit Polygon2D *"
 
 [node name="GotoPolygon2DButton" type="Button" parent="ButtonContainer2"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 2
 tooltip_text = "Click on this button to select the Polygon2D node that is assigned to this shape  in the Scene Tree.

--- a/addons/curved_lines_2d/assign_navigation_region_inspector_form.gd
+++ b/addons/curved_lines_2d/assign_navigation_region_inspector_form.gd
@@ -15,11 +15,11 @@ func _enter_tree() -> void:
 
 func _on_svs_assignment_changed() -> void:
 	if is_instance_valid(scalable_vector_shape_2d.navigation_region):
-		get_node("%GoToNavigationRegionButton").show()
-		get_node("%AddNavigationRegionButton").hide()
+		%GoToNavigationRegionButton.show()
+		%AddNavigationRegionButton.hide()
 	else:
-		get_node("%GoToNavigationRegionButton").hide()
-		get_node("%AddNavigationRegionButton").show()
+		%GoToNavigationRegionButton.hide()
+		%AddNavigationRegionButton.show()
 
 
 func _on_add_navigation_region_button_pressed() -> void:

--- a/addons/curved_lines_2d/assign_stroke_inspector_form.gd
+++ b/addons/curved_lines_2d/assign_stroke_inspector_form.gd
@@ -4,9 +4,6 @@ extends KeyframeButtonCapableInspectorFormBase
 class_name AssignStrokeInspectorForm
 
 var scalable_vector_shape_2d : ScalableVectorShape2D
-var create_button : Button
-var select_button : Button
-var color_button : ColorPickerButton
 var stroke_width_input : EditorSpinSlider
 
 var begin_cap_button_map = {}
@@ -16,22 +13,19 @@ var joint_button_map = {}
 func _enter_tree() -> void:
 	if not is_instance_valid(scalable_vector_shape_2d):
 		return
-	create_button = find_child("CreateStrokeButton")
-	select_button = find_child("GotoLine2DButton")
-	color_button = find_child("ColorPickerButton")
 	if 'assigned_node_changed' in scalable_vector_shape_2d:
 		scalable_vector_shape_2d.assigned_node_changed.connect(_on_svs_assignment_changed)
 	stroke_width_input = _make_float_input("Stroke Width", 10.0, 0.0, 100.0, "px")
-	find_child("StrokeWidthFloatFieldContainer").add_child(stroke_width_input)
-	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_NONE] = find_child("BeginNoCapToggleButton")
-	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_BOX] = find_child("BeginBoxCapToggleButton")
-	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_ROUND] = find_child("BeginRoundCapToggleButton")
-	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_NONE] = find_child("EndNoCapToggleButton")
-	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_BOX] = find_child("EndBoxCapToggleButton")
-	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_ROUND] = find_child("EndRoundCapToggleButton")
-	joint_button_map[Line2D.LineJointMode.LINE_JOINT_SHARP] = find_child("LineJointSharpToggleButton")
-	joint_button_map[Line2D.LineJointMode.LINE_JOINT_BEVEL] = find_child("LineJointBevelToggleButton")
-	joint_button_map[Line2D.LineJointMode.LINE_JOINT_ROUND] = find_child("LineJointRoundToggleButton")
+	%StrokeWidthFloatFieldContainer.add_child(stroke_width_input)
+	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_NONE] = %BeginNoCapToggleButton
+	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_BOX] = %BeginBoxCapToggleButton
+	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_ROUND] = %BeginRoundCapToggleButton
+	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_NONE] = %EndNoCapToggleButton
+	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_BOX] = %EndBoxCapToggleButton
+	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_ROUND] = %EndRoundCapToggleButton
+	joint_button_map[Line2D.LineJointMode.LINE_JOINT_SHARP] = %LineJointSharpToggleButton
+	joint_button_map[Line2D.LineJointMode.LINE_JOINT_BEVEL] = %LineJointBevelToggleButton
+	joint_button_map[Line2D.LineJointMode.LINE_JOINT_ROUND] = %LineJointRoundToggleButton
 	_on_svs_assignment_changed()
 	stroke_width_input.value_changed.connect(_on_stroke_width_changed)
 	_initialize_keyframe_capabilities()
@@ -39,22 +33,22 @@ func _enter_tree() -> void:
 
 func _on_svs_assignment_changed() -> void:
 	if is_instance_valid(scalable_vector_shape_2d.line):
-		create_button.get_parent().hide()
-		select_button.get_parent().show()
-		create_button.disabled = true
-		select_button.disabled = false
+		%CreateStrokeButton.get_parent().hide()
+		%GotoLine2DButton.get_parent().show()
+		%CreateStrokeButton.disabled = true
+		%GotoLine2DButton.disabled = false
 		stroke_width_input.value = scalable_vector_shape_2d.line.width
-		color_button.color = scalable_vector_shape_2d.line.default_color
+		%ColorPickerButton.color = scalable_vector_shape_2d.line.default_color
 		begin_cap_button_map[scalable_vector_shape_2d.line.begin_cap_mode].button_pressed = true
 		end_cap_button_map[scalable_vector_shape_2d.line.end_cap_mode].button_pressed = true
 		joint_button_map[scalable_vector_shape_2d.line.joint_mode].button_pressed = true
 	else:
-		create_button.get_parent().show()
-		select_button.get_parent().hide()
-		create_button.disabled = false
-		select_button.disabled = true
+		%CreateStrokeButton.get_parent().show()
+		%GotoLine2DButton.get_parent().hide()
+		%CreateStrokeButton.disabled = false
+		%GotoLine2DButton.disabled = true
 		stroke_width_input.value = CurvedLines2D._get_default_stroke_width()
-		color_button.color = CurvedLines2D._get_default_stroke_color()
+		%ColorPickerButton.color = CurvedLines2D._get_default_stroke_color()
 		begin_cap_button_map[CurvedLines2D._get_default_begin_cap()].button_pressed = true
 		end_cap_button_map[CurvedLines2D._get_default_end_cap()].button_pressed = true
 		joint_button_map[CurvedLines2D._get_default_joint_mode()].button_pressed = true
@@ -116,7 +110,7 @@ func _on_create_stroke_button_pressed():
 	var line_2d := Line2D.new()
 	var root := EditorInterface.get_edited_scene_root()
 	var undo_redo = EditorInterface.get_editor_undo_redo()
-	line_2d.default_color = color_button.color
+	line_2d.default_color = %ColorPickerButton.color
 	line_2d.width = stroke_width_input.value
 	line_2d.begin_cap_mode = _get_selected_begin_cap_mode()
 	line_2d.end_cap_mode = _get_selected_end_cap_mode()
@@ -154,13 +148,13 @@ func _on_add_stroke_width_key_frame_button_pressed() -> void:
 func _on_add_stroke_color_key_frame_button_pressed() -> void:
 	if is_instance_valid(scalable_vector_shape_2d.line):
 		add_key_frame(
-			scalable_vector_shape_2d.line, "default_color", color_button.color
+			scalable_vector_shape_2d.line, "default_color", %ColorPickerButton.color
 		)
 
 
 func _on_key_frame_capabilities_changed():
-	find_child("AddStrokeColorKeyFrameButton").visible = _is_key_frame_capable()
-	find_child("AddStrokeWidthKeyFrameButton").visible = _is_key_frame_capable()
+	%AddStrokeColorKeyFrameButton.visible = _is_key_frame_capable()
+	%AddStrokeWidthKeyFrameButton.visible = _is_key_frame_capable()
 
 
 func _on_color_picker_button_toggled(toggled_on: bool) -> void:
@@ -170,10 +164,10 @@ func _on_color_picker_button_toggled(toggled_on: bool) -> void:
 	if toggled_on:
 		undo_redo.create_action("Adjust Line2D default_color for %s" % str(scalable_vector_shape_2d))
 		undo_redo.add_undo_property(scalable_vector_shape_2d.line, 'default_color', scalable_vector_shape_2d.line.default_color)
-		undo_redo.add_undo_property(color_button, 'color', scalable_vector_shape_2d.line.default_color)
+		undo_redo.add_undo_property(%ColorPickerButton, 'color', scalable_vector_shape_2d.line.default_color)
 	else:
-		undo_redo.add_do_property(scalable_vector_shape_2d.line, 'default_color', color_button.color)
-		undo_redo.add_do_property(color_button, 'color', color_button.color)
+		undo_redo.add_do_property(scalable_vector_shape_2d.line, 'default_color', %ColorPickerButton.color)
+		undo_redo.add_do_property(%ColorPickerButton, 'color', %ColorPickerButton.color)
 		undo_redo.commit_action(false)
 
 

--- a/addons/curved_lines_2d/assign_stroke_inspector_form.tscn
+++ b/addons/curved_lines_2d/assign_stroke_inspector_form.tscn
@@ -60,6 +60,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="ColorPickerButton" type="ColorPickerButton" parent="StrokeColorFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "This will set the default_color of the assigned Line2D."
@@ -67,6 +68,7 @@ text = "Stroke"
 color = Color(1, 1, 1, 1)
 
 [node name="AddStrokeColorKeyFrameButton" type="Button" parent="StrokeColorFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Click to add a key frame to the current animation for the Line2D's default_color property"
 icon = ExtResource("3_2fv2a")
@@ -88,11 +90,13 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="StrokeWidthFloatFieldContainer" type="PanelContainer" parent="StrokeWidthFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "This will set the width of the assign Line2D node"
 
 [node name="AddStrokeWidthKeyFrameButton" type="Button" parent="StrokeWidthFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Click to add a key frame to the current animation for the Line2D's width property"
 icon = ExtResource("3_2fv2a")
@@ -119,6 +123,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="BeginNoCapToggleButton" type="Button" parent="BeginLineCapFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -138,6 +143,7 @@ button_group = SubResource("ButtonGroup_yspdc")
 icon = SubResource("AtlasTexture_skbna")
 
 [node name="BeginBoxCapToggleButton" type="Button" parent="BeginLineCapFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -157,6 +163,7 @@ button_group = SubResource("ButtonGroup_yspdc")
 icon = SubResource("AtlasTexture_kyj8c")
 
 [node name="BeginRoundCapToggleButton" type="Button" parent="BeginLineCapFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -197,6 +204,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="EndNoCapToggleButton" type="Button" parent="EndLineCapFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -216,6 +224,7 @@ button_group = SubResource("ButtonGroup_df4us")
 icon = SubResource("AtlasTexture_skbna")
 
 [node name="EndBoxCapToggleButton" type="Button" parent="EndLineCapFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -235,6 +244,7 @@ button_group = SubResource("ButtonGroup_df4us")
 icon = SubResource("AtlasTexture_kyj8c")
 
 [node name="EndRoundCapToggleButton" type="Button" parent="EndLineCapFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -273,6 +283,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="LineJointSharpToggleButton" type="Button" parent="LineJointFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -291,6 +302,7 @@ button_group = SubResource("ButtonGroup_bop6d")
 icon = SubResource("AtlasTexture_yspdc")
 
 [node name="LineJointBevelToggleButton" type="Button" parent="LineJointFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -308,6 +320,7 @@ button_group = SubResource("ButtonGroup_bop6d")
 icon = SubResource("AtlasTexture_rv3vu")
 
 [node name="LineJointRoundToggleButton" type="Button" parent="LineJointFieldContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -337,6 +350,7 @@ mouse_filter = 0
 text = "Add Stroke"
 
 [node name="CreateStrokeButton" type="Button" parent="ButtonContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 2
 tooltip_text = "This will create a new Line2D node and assign it to the line property of this ScalableVectorScape2D."
@@ -359,6 +373,7 @@ mouse_filter = 0
 text = "Edit Line2D *"
 
 [node name="GotoLine2DButton" type="Button" parent="ButtonContainer2"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 2
 tooltip_text = "Click on this button to select the Line2D node that is assigned to this shape  in the Scene Tree.

--- a/addons/curved_lines_2d/batch_insert_curve_point_key_frames_inspector_form.gd
+++ b/addons/curved_lines_2d/batch_insert_curve_point_key_frames_inspector_form.gd
@@ -1,19 +1,17 @@
 @tool
 extends KeyframeButtonCapableInspectorFormBase
 
-var batch_insert_button : Button
 var scalable_vector_shape_2d : ScalableVectorShape2D
 
 func _enter_tree() -> void:
-	batch_insert_button = find_child("BatchInsertButton")
 	_initialize_keyframe_capabilities()
 
 
 func _on_key_frame_capabilities_changed() -> void:
 	if _is_key_frame_capable():
-		batch_insert_button.disabled = false
+		%BatchInsertButton.disabled = false
 	else:
-		batch_insert_button.disabled = true
+		%BatchInsertButton.disabled = true
 
 
 func _on_batch_insert_button_pressed() -> void:

--- a/addons/curved_lines_2d/batch_insert_curve_point_key_frames_inspector_form.tscn
+++ b/addons/curved_lines_2d/batch_insert_curve_point_key_frames_inspector_form.tscn
@@ -30,6 +30,7 @@ mouse_filter = 0
 text = "Insert key frames*"
 
 [node name="BatchInsertButton" type="Button" parent="HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "- Clicking this button will insert key frames for all the curve points and control points at the current animation postion for all their property tracks

--- a/addons/curved_lines_2d/import_svg_file_tab.gd
+++ b/addons/curved_lines_2d/import_svg_file_tab.gd
@@ -34,8 +34,6 @@ const STROKE_JOINT_MAP := {
 }
 
 enum LogLevel { DEBUG, INFO, WARN, ERROR }
-var log_scroll_container : ScrollContainer = null
-var log_container : VBoxContainer = null
 var error_label_settings : LabelSettings = null
 var warning_label_settings : LabelSettings = null
 var info_label_settings : LabelSettings = null
@@ -44,9 +42,7 @@ var debug_label_settings : LabelSettings = null
 ## Settings
 var collision_object_type := ScalableVectorShape2D.CollisionObjectType.NONE
 var import_collision_polygons_for_all_shapes := false
-var import_collision_polygons_for_all_shapes_checkbox : Control = null
 var keep_drawable_path_node := true
-var lock_shapes_checkbox : Control = null
 var lock_shapes := true
 var antialiased_shapes := false
 var import_file_dialog : EditorFileDialog = null
@@ -55,16 +51,12 @@ var undo_redo : EditorUndoRedoManager = null
 var LinkButtonScene : PackedScene = null
 
 func _enter_tree() -> void:
-	log_scroll_container = find_child("ScrollContainer")
-	log_container = find_child("ImportLogContainer")
-	import_collision_polygons_for_all_shapes_checkbox = find_child("ImportCollisionPolygonsForAllShapesCheckBox")
-	lock_shapes_checkbox = find_child("LockShapesCheckBox")
 	error_label_settings = preload("res://addons/curved_lines_2d/error_label_settings.tres")
 	warning_label_settings = preload("res://addons/curved_lines_2d/warn_label_settings.tres")
 	info_label_settings = preload("res://addons/curved_lines_2d/info_label_settings.tres")
 	debug_label_settings = preload("res://addons/curved_lines_2d/debug_label_settings.tres")
 	LinkButtonScene = preload("res://addons/curved_lines_2d/link_button_with_copy_hint.tscn")
-	log_scroll_container.get_v_scroll_bar().connect("changed", func(): log_scroll_container.scroll_vertical = log_scroll_container.get_v_scroll_bar().max_value )
+	%LogScrollContainer.get_v_scroll_bar().connect("changed", func(): %LogScrollContainer.scroll_vertical = %LogScrollContainer.get_v_scroll_bar().max_value )
 	import_file_dialog = EditorFileDialog.new()
 	import_file_dialog.add_filter("*.svg", "SVG image")
 	import_file_dialog.file_mode = EditorFileDialog.FILE_MODE_OPEN_FILE
@@ -96,7 +88,7 @@ func log_message(msg : String, log_level : LogLevel = LogLevel.INFO) -> void:
 		LogLevel.INFO,_:
 			lbl.label_settings = info_label_settings
 	lbl.text = msg
-	log_container.add_child(lbl)
+	%ImportLogContainer.add_child(lbl)
 
 
 func _drop_data(at_position: Vector2, data: Variant) -> void:
@@ -112,7 +104,7 @@ func _get_viewport_center() -> Vector2:
 
 
 func _load_svg(file_path : String) -> void:
-	for child in log_container.get_children():
+	for child in %ImportLogContainer.get_children():
 		child.queue_free()
 	var xml_data = XMLParser.new()
 	var scene_root := EditorInterface.get_edited_scene_root()
@@ -184,14 +176,14 @@ func _load_svg(file_path : String) -> void:
 	var link_button : LinkButtonWithCopyHint = LinkButtonScene.instantiate()
 	link_button.text = "Click here to report issues or improvement requests on github"
 	link_button.uri = "https://github.com/Teaching-myself-Godot/ez-curved-lines-2d/issues"
-	log_container.add_child(link_button)
+	%ImportLogContainer.add_child(link_button)
 
 	log_message("\nClick on the link below to learn more")
 
 	var link_button2 : LinkButtonWithCopyHint = LinkButtonScene.instantiate()
 	link_button2.text = "Watch an explainer about known issues on youtube."
 	link_button2.uri = "https://www.youtube.com/watch?v=nVCKVRBMnWU"
-	log_container.add_child(link_button2)
+	%ImportLogContainer.add_child(link_button2)
 	undo_redo.commit_action(false)
 	EditorInterface.call_deferred('edit_node', svg_root)
 
@@ -804,7 +796,7 @@ static func parse_attribute_string(raw_attribute_str : String) -> String:
 
 func _on_collision_object_type_option_button_type_selected(obj_type: ScalableVectorShape2D.CollisionObjectType) -> void:
 	collision_object_type = obj_type
-	import_collision_polygons_for_all_shapes_checkbox.visible = obj_type != ScalableVectorShape2D.CollisionObjectType.NONE
+	%ImportCollisionPolygonsForAllShapesCheckBox.visible = obj_type != ScalableVectorShape2D.CollisionObjectType.NONE
 
 
 func _on_import_collision_polygons_for_all_shapes_check_box_toggled(toggled_on: bool) -> void:
@@ -813,7 +805,7 @@ func _on_import_collision_polygons_for_all_shapes_check_box_toggled(toggled_on: 
 
 func _on_keep_drawable_path_2d_node_check_box_toggled(toggled_on: bool) -> void:
 	keep_drawable_path_node = toggled_on
-	lock_shapes_checkbox.visible = toggled_on
+	%LockShapesCheckBox.visible = toggled_on
 
 
 func _on_lock_shapes_check_box_toggled(toggled_on: bool) -> void:
@@ -826,5 +818,3 @@ func _on_antialiased_check_box_toggled(toggled_on: bool) -> void:
 
 func _on_open_file_dialog_button_pressed() -> void:
 	import_file_dialog.popup_file_dialog()
-
-

--- a/addons/curved_lines_2d/import_svg_file_tab.tscn
+++ b/addons/curved_lines_2d/import_svg_file_tab.tscn
@@ -28,7 +28,7 @@ border_width_bottom = 4
 border_color = Color(0.439216, 0.729412, 0.980392, 1)
 border_blend = true
 
-[node name="Import SVG File" type="HBoxContainer"]
+[node name="ImportSVGFileTab" type="HBoxContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -55,15 +55,15 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_rycm0")
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer2/PanelContainer"]
 layout_mode = 2
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer2/PanelContainer/VBoxContainer2"]
+[node name="SettingsScrollContainer" type="ScrollContainer" parent="VBoxContainer2/PanelContainer/VBoxContainer2"]
 layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 10.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer"]
 layout_mode = 2
 
-[node name="KeepDrawablePath2DNodeCheckBox" type="CheckBox" parent="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer"]
+[node name="KeepDrawablePath2DNodeCheckBox" type="CheckBox" parent="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer"]
 layout_mode = 2
 tooltip_text = "- When checked on, all shapes in the SVG file will be imported as ScalableVectorShape2D (this is advised)
 - Checking this off will only add builtin nodes the scene (Line2D, Polygon2D, CollisionPolygon2D as child of Node2D). It will print errors, because of missing references.
@@ -71,7 +71,8 @@ tooltip_text = "- When checked on, all shapes in the SVG file will be imported a
 button_pressed = true
 text = "Import as ScalableVectorShape2D*"
 
-[node name="LockShapesCheckBox" type="CheckBox" parent="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer"]
+[node name="LockShapesCheckBox" type="CheckBox" parent="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "- Adds a lock to the Line2D, Polygon2D and CollisionPolygon2D assigned to the ScalableVectorShape2D
 - This lock makes sure these nodes are not transformed via the 2D editor"
@@ -79,15 +80,16 @@ button_pressed = true
 text = "Lock imported shapes in editor *"
 icon = ExtResource("2_38alv")
 
-[node name="AntialiasedCheckBox" type="CheckBox" parent="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer"]
+[node name="AntialiasedCheckBox" type="CheckBox" parent="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer"]
 layout_mode = 2
 tooltip_text = "It's probably better to use project settings for this, but checking this on will ensure that the antialised property is checked on for imported Line2D and Polygon2D"
 text = "Flag on antialiased for Polygon2D and Line2D*"
 
-[node name="CollisionObjectTypeOptionButton" parent="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer" instance=ExtResource("3_kpb1b")]
+[node name="CollisionObjectTypeOptionButton" parent="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer" instance=ExtResource("3_kpb1b")]
 layout_mode = 2
 
-[node name="ImportCollisionPolygonsForAllShapesCheckBox" type="CheckBox" parent="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer"]
+[node name="ImportCollisionPolygonsForAllShapesCheckBox" type="CheckBox" parent="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer"]
+unique_name_in_owner = true
 visible = false
 layout_mode = 2
 tooltip_text = "- Checking this on will make sure that shapes with only strokes will still generate a CollisionPolygon2D
@@ -107,25 +109,27 @@ size_flags_horizontal = 3
 layout_mode = 2
 text = "SVG Import Log"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
+[node name="LogScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_gt4al")
 
-[node name="ImportLogContainer" type="VBoxContainer" parent="VBoxContainer/ScrollContainer"]
+[node name="ImportLogContainer" type="VBoxContainer" parent="VBoxContainer/LogScrollContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = -5
 
-[node name="Label" type="Label" parent="VBoxContainer/ScrollContainer/ImportLogContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/LogScrollContainer/ImportLogContainer"]
 layout_mode = 2
 size_flags_vertical = 10
 text = " - Drag/Drop an svg-file here to start import -"
 label_settings = ExtResource("1_x2xey")
 horizontal_alignment = 1
 
-[node name="LinkButton2" parent="VBoxContainer/ScrollContainer/ImportLogContainer" instance=ExtResource("2_fhkel")]
+[node name="LinkButton2" parent="VBoxContainer/LogScrollContainer/ImportLogContainer" instance=ExtResource("2_fhkel")]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 2
@@ -134,9 +138,9 @@ Right click to copy this link"
 text = "Watch an explainer on Youtube"
 uri = "https://youtu.be/3j_OEfU8qbo?feature=shared"
 
-[connection signal="toggled" from="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer/KeepDrawablePath2DNodeCheckBox" to="." method="_on_keep_drawable_path_2d_node_check_box_toggled"]
-[connection signal="toggled" from="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer/LockShapesCheckBox" to="." method="_on_lock_shapes_check_box_toggled"]
-[connection signal="toggled" from="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer/AntialiasedCheckBox" to="." method="_on_antialiased_check_box_toggled"]
-[connection signal="type_selected" from="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer/CollisionObjectTypeOptionButton" to="." method="_on_collision_object_type_option_button_type_selected"]
-[connection signal="toggled" from="VBoxContainer2/PanelContainer/VBoxContainer2/ScrollContainer/VBoxContainer/ImportCollisionPolygonsForAllShapesCheckBox" to="." method="_on_import_collision_polygons_for_all_shapes_check_box_toggled"]
+[connection signal="toggled" from="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer/KeepDrawablePath2DNodeCheckBox" to="." method="_on_keep_drawable_path_2d_node_check_box_toggled"]
+[connection signal="toggled" from="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer/LockShapesCheckBox" to="." method="_on_lock_shapes_check_box_toggled"]
+[connection signal="toggled" from="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer/AntialiasedCheckBox" to="." method="_on_antialiased_check_box_toggled"]
+[connection signal="type_selected" from="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer/CollisionObjectTypeOptionButton" to="." method="_on_collision_object_type_option_button_type_selected"]
+[connection signal="toggled" from="VBoxContainer2/PanelContainer/VBoxContainer2/SettingsScrollContainer/VBoxContainer/ImportCollisionPolygonsForAllShapesCheckBox" to="." method="_on_import_collision_polygons_for_all_shapes_check_box_toggled"]
 [connection signal="pressed" from="VBoxContainer2/PanelContainer/VBoxContainer2/OpenFileDialogButton" to="." method="_on_open_file_dialog_button_pressed"]

--- a/addons/curved_lines_2d/keyframe_button_capable_inspector_form_base.gd
+++ b/addons/curved_lines_2d/keyframe_button_capable_inspector_form_base.gd
@@ -38,7 +38,7 @@ func _is_key_frame_capable() -> bool:
 
 
 func _find_animation_player(with_anim_name : String) -> AnimationPlayer:
-	for n  in EditorInterface.get_edited_scene_root().find_children("*", "AnimationPlayer", true):
+	for n in EditorInterface.get_edited_scene_root().find_children("*", "AnimationPlayer", true):
 		if n is AnimationPlayer and (n as AnimationPlayer).has_animation(with_anim_name):
 			return n
 	return null

--- a/addons/curved_lines_2d/scalable_vector_shape_edit_tab.gd
+++ b/addons/curved_lines_2d/scalable_vector_shape_edit_tab.gd
@@ -9,8 +9,6 @@ signal ellipse_created(rx : float, ry : float, scene_root : Node2D)
 signal set_shape_preview(curve : Curve2D)
 
 var stroke_width_input : EditorSpinSlider
-var stroke_color_button : ColorPickerButton
-var fill_color_button : ColorPickerButton
 
 var rect_width_input : EditorSpinSlider
 var rect_height_input : EditorSpinSlider
@@ -35,42 +33,40 @@ func _enter_tree() -> void:
 	rect_ry_input = _make_number_input("Corner Radius Y", 0, 0, 500, "")
 	snap_resolution_input = _make_number_input("Snap distance", 1.0, 1.0, 1024.0, "px", 1.0)
 
-	stroke_color_button = find_child("StrokePickerButton")
-	fill_color_button = find_child("FillPickerButton")
 	stroke_width_input = _make_number_input("Width", 10.0, 0.0, 100.0, "", 0.01)
-	find_child("WidthSliderContainer").add_child(rect_width_input)
-	find_child("HeightSliderContainer").add_child(rect_height_input)
-	find_child("XRadiusSliderContainer").add_child(rect_rx_input)
-	find_child("YRadiusSliderContainer").add_child(rect_ry_input)
-	find_child("StrokeWidthContainer").add_child(stroke_width_input)
+	%WidthSliderContainer.add_child(rect_width_input)
+	%HeightSliderContainer.add_child(rect_height_input)
+	%XRadiusSliderContainer.add_child(rect_rx_input)
+	%YRadiusSliderContainer.add_child(rect_ry_input)
+	%StrokeWidthContainer.add_child(stroke_width_input)
 	ellipse_rx_input = _make_number_input("Horizontal Radius (RX)", 50, 1, 500, "")
 	ellipse_ry_input = _make_number_input("Vertical Radius (RY)", 50, 1, 500, "")
-	find_child("EllipseXRadiusSliderContainer").add_child(ellipse_rx_input)
-	find_child("EllipseYRadiusSliderContainer").add_child(ellipse_ry_input)
-	find_child("EnableEditingCheckbox").button_pressed = CurvedLines2D._is_editing_enabled()
-	find_child("EnableHintsCheckbox").button_pressed = CurvedLines2D._are_hints_enabled()
-	find_child("EnablePointNumbersCheckbox").button_pressed = CurvedLines2D._am_showing_point_numbers()
-	find_child("SnapToPixelCheckBox").button_pressed = CurvedLines2D._is_snapped_to_pixel()
+	%EllipseXRadiusSliderContainer.add_child(ellipse_rx_input)
+	%EllipseYRadiusSliderContainer.add_child(ellipse_ry_input)
+	%EnableEditingCheckbox.button_pressed = CurvedLines2D._is_editing_enabled()
+	%EnableHintsCheckbox.button_pressed = CurvedLines2D._are_hints_enabled()
+	%EnablePointNumbersCheckbox.button_pressed = CurvedLines2D._am_showing_point_numbers()
+	%SnapToPixelCheckBox.button_pressed = CurvedLines2D._is_snapped_to_pixel()
 	stroke_width_input.value = CurvedLines2D._get_default_stroke_width()
 	stroke_width_input.value_changed.connect(_on_stroke_width_input_value_changed)
-	stroke_color_button.color = CurvedLines2D._get_default_stroke_color()
-	fill_color_button.color = CurvedLines2D._get_default_fill_color()
-	find_child("StrokeCheckButton").button_pressed = CurvedLines2D._is_add_stroke_enabled()
-	find_child("FillCheckButton").button_pressed = CurvedLines2D._is_add_fill_enabled()
-	(find_child("CollisionObjectTypeOptionButton") as OptionButton).select(CurvedLines2D._add_collision_object_type())
-	find_child("SnapResolutionInputContainer").add_child(snap_resolution_input)
+	%StrokePickerButton.color = CurvedLines2D._get_default_stroke_color()
+	%FillPickerButton.color = CurvedLines2D._get_default_fill_color()
+	%StrokeCheckButton.button_pressed = CurvedLines2D._is_add_stroke_enabled()
+	%FillCheckButton.button_pressed = CurvedLines2D._is_add_fill_enabled()
+	(%CollisionObjectTypeOptionButton as OptionButton).select(CurvedLines2D._add_collision_object_type())
+	%SnapResolutionInputContainer.add_child(snap_resolution_input)
 	snap_resolution_input.value = CurvedLines2D._get_snap_resolution()
 	snap_resolution_input.value_changed.connect(_on_snap_resolution_value_changed)
 
-	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_NONE] = find_child("BeginNoCapToggleButton")
-	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_BOX] = find_child("BeginBoxCapToggleButton")
-	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_ROUND] = find_child("BeginRoundCapToggleButton")
-	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_NONE] = find_child("EndNoCapToggleButton")
-	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_BOX] = find_child("EndBoxCapToggleButton")
-	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_ROUND] = find_child("EndRoundCapToggleButton")
-	joint_button_map[Line2D.LineJointMode.LINE_JOINT_SHARP] = find_child("LineJointSharpToggleButton")
-	joint_button_map[Line2D.LineJointMode.LINE_JOINT_BEVEL] = find_child("LineJointBevelToggleButton")
-	joint_button_map[Line2D.LineJointMode.LINE_JOINT_ROUND] = find_child("LineJointRoundToggleButton")
+	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_NONE] = %BeginNoCapToggleButton
+	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_BOX] = %BeginBoxCapToggleButton
+	begin_cap_button_map[Line2D.LineCapMode.LINE_CAP_ROUND] = %BeginRoundCapToggleButton
+	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_NONE] = %EndNoCapToggleButton
+	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_BOX] = %EndBoxCapToggleButton
+	end_cap_button_map[Line2D.LineCapMode.LINE_CAP_ROUND] = %EndRoundCapToggleButton
+	joint_button_map[Line2D.LineJointMode.LINE_JOINT_SHARP] = %LineJointSharpToggleButton
+	joint_button_map[Line2D.LineJointMode.LINE_JOINT_BEVEL] = %LineJointBevelToggleButton
+	joint_button_map[Line2D.LineJointMode.LINE_JOINT_ROUND] = %LineJointRoundToggleButton
 	begin_cap_button_map[CurvedLines2D._get_default_begin_cap()].button_pressed = true
 	end_cap_button_map[CurvedLines2D._get_default_end_cap()].button_pressed = true
 	joint_button_map[CurvedLines2D._get_default_joint_mode()].button_pressed = true
@@ -78,10 +74,10 @@ func _enter_tree() -> void:
 
 	if not stroke_width_input.value_focus_exited.is_connected(ProjectSettings.save):
 		stroke_width_input.value_focus_exited.connect(ProjectSettings.save)
-	if not stroke_color_button.focus_exited.is_connected(ProjectSettings.save):
-		stroke_color_button.focus_exited.connect(ProjectSettings.save)
-	if not fill_color_button.focus_exited.is_connected(ProjectSettings.save):
-		fill_color_button.focus_exited.connect(ProjectSettings.save)
+	if not %StrokePickerButton.focus_exited.is_connected(ProjectSettings.save):
+		%StrokePickerButton.focus_exited.connect(ProjectSettings.save)
+	if not %FillPickerButton.focus_exited.is_connected(ProjectSettings.save):
+		%FillPickerButton.focus_exited.connect(ProjectSettings.save)
 	if not snap_resolution_input.focus_exited.is_connected(ProjectSettings.save):
 		snap_resolution_input.focus_exited.connect(ProjectSettings.save)
 	find_children("PaintOrderButton*")[CurvedLines2D._get_default_paint_order()].button_pressed = true

--- a/addons/curved_lines_2d/scalable_vector_shape_edit_tab.tscn
+++ b/addons/curved_lines_2d/scalable_vector_shape_edit_tab.tscn
@@ -105,18 +105,21 @@ mouse_filter = 0
 text = "Editor Settings*"
 
 [node name="EnableEditingCheckbox" type="CheckBox" parent="VBoxContainer/EditorSettingsContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 button_pressed = true
 text = "Enable ScalableVectorShape2D Editing"
 
 [node name="EnableHintsCheckbox" type="CheckBox" parent="VBoxContainer/EditorSettingsContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 button_pressed = true
 text = "Show Edit Hints"
 
 [node name="EnablePointNumbersCheckbox" type="CheckBox" parent="VBoxContainer/EditorSettingsContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 tooltip_text = "When active, when hovering over a point / handle in the curve
@@ -126,6 +129,7 @@ button_pressed = true
 text = "Show Point Details*"
 
 [node name="SnapToPixelCheckBox" type="CheckBox" parent="VBoxContainer/EditorSettingsContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 tooltip_text = "When active, points you move will snap to whole numbers:
@@ -135,6 +139,7 @@ button_pressed = true
 text = "Snap to pixel*"
 
 [node name="SnapResolutionInputContainer" type="PanelContainer" parent="VBoxContainer/EditorSettingsContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
@@ -152,6 +157,7 @@ mouse_filter = 0
 text = "Draw Settings*"
 
 [node name="FillCheckButton" type="CheckButton" parent="VBoxContainer/DrawSettingsContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
 tooltip_text = "- Toggled On: when creating a new shape via this panel, a Fill (Polygon2D) of this color will be automatically added
@@ -162,6 +168,7 @@ text = "Fill*"
 alignment = 2
 
 [node name="FillPickerButton" type="ColorPickerButton" parent="VBoxContainer/DrawSettingsContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(42, 0)
 layout_mode = 2
 size_flags_horizontal = 8
@@ -169,6 +176,7 @@ text = "Fill"
 color = Color(1, 1, 1, 1)
 
 [node name="StrokeCheckButton" type="CheckButton" parent="VBoxContainer/DrawSettingsContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
 tooltip_text = "- Toggled On: when creating a new shape via this panel, a Stroke (Line2D) of this color will be automatically added
@@ -179,6 +187,7 @@ text = "Stroke*"
 alignment = 2
 
 [node name="StrokePickerButton" type="ColorPickerButton" parent="VBoxContainer/DrawSettingsContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(42, 0)
 layout_mode = 2
 size_flags_horizontal = 8
@@ -186,6 +195,7 @@ text = "Fill"
 color = Color(1, 1, 1, 1)
 
 [node name="CollisionObjectTypeOptionButton" parent="VBoxContainer/DrawSettingsContainer" instance=ExtResource("2_kh00m")]
+unique_name_in_owner = true
 layout_mode = 2
 
 [node name="Label" type="Label" parent="VBoxContainer/DrawSettingsContainer"]
@@ -309,6 +319,7 @@ mouse_filter = 0
 text = "Stroke Settings*"
 
 [node name="StrokeWidthContainer" type="PanelContainer" parent="VBoxContainer/StrokeSettingsContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(120, 0)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -332,6 +343,7 @@ text = "Begin Cap Mode*"
 horizontal_alignment = 2
 
 [node name="BeginNoCapToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -351,6 +363,7 @@ button_group = SubResource("ButtonGroup_kh00m")
 icon = SubResource("AtlasTexture_85hwe")
 
 [node name="BeginBoxCapToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -370,6 +383,7 @@ button_group = SubResource("ButtonGroup_kh00m")
 icon = SubResource("AtlasTexture_nh347")
 
 [node name="BeginRoundCapToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -407,6 +421,7 @@ text = "End Cap Mode *"
 horizontal_alignment = 2
 
 [node name="EndNoCapToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer2"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -426,6 +441,7 @@ button_group = SubResource("ButtonGroup_k2toy")
 icon = SubResource("AtlasTexture_2t4g6")
 
 [node name="EndBoxCapToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer2"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -445,6 +461,7 @@ button_group = SubResource("ButtonGroup_k2toy")
 icon = SubResource("AtlasTexture_pf6gx")
 
 [node name="EndRoundCapToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer2"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -480,6 +497,7 @@ text = "Joint Mode*"
 horizontal_alignment = 2
 
 [node name="LineJointSharpToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer3"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -498,6 +516,7 @@ button_group = SubResource("ButtonGroup_xku8w")
 icon = SubResource("AtlasTexture_k2toy")
 
 [node name="LineJointBevelToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer3"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -515,6 +534,7 @@ button_group = SubResource("ButtonGroup_xku8w")
 icon = SubResource("AtlasTexture_em7di")
 
 [node name="LineJointRoundToggleButton" type="Button" parent="VBoxContainer/StrokeSettingsContainer/HBoxContainer3"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -547,20 +567,24 @@ mouse_filter = 0
 text = "Create Rectangle*"
 
 [node name="WidthSliderContainer" type="PanelContainer" parent="VBoxContainer/RectBuilderContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="HeightSliderContainer" type="PanelContainer" parent="VBoxContainer/RectBuilderContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="XRadiusSliderContainer" type="PanelContainer" parent="VBoxContainer/RectBuilderContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="YRadiusSliderContainer" type="PanelContainer" parent="VBoxContainer/RectBuilderContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
@@ -594,10 +618,12 @@ mouse_filter = 0
 text = "Create Ellipse*"
 
 [node name="EllipseXRadiusSliderContainer" type="PanelContainer" parent="VBoxContainer/EllipseBuilderContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="EllipseYRadiusSliderContainer" type="PanelContainer" parent="VBoxContainer/EllipseBuilderContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 

--- a/addons/curved_lines_2d/set_global_position_popup_panel.gd
+++ b/addons/curved_lines_2d/set_global_position_popup_panel.gd
@@ -13,8 +13,8 @@ var _drag_start := Vector2.ZERO
 func _enter_tree() -> void:
 	x_pos_input = _mk_input()
 	y_pos_input = _mk_input()
-	find_child("XPosInputContainer").add_child(x_pos_input)
-	find_child("YPosInputContainer").add_child(y_pos_input)
+	%XPosInputContainer.add_child(x_pos_input)
+	%YPosInputContainer.add_child(y_pos_input)
 	if not x_pos_input.value_changed.is_connected(_on_value_changed):
 		x_pos_input.value_changed.connect(_on_value_changed)
 	if not y_pos_input.value_changed.is_connected(_on_value_changed):

--- a/addons/curved_lines_2d/set_global_position_popup_panel.tscn
+++ b/addons/curved_lines_2d/set_global_position_popup_panel.tscn
@@ -69,6 +69,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="XPosInputContainer" type="PanelContainer" parent="VBoxContainer/PanelContainer/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_vlbak")
@@ -92,6 +93,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="YPosInputContainer" type="PanelContainer" parent="VBoxContainer/PanelContainer2/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_vlbak")


### PR DESCRIPTION
Issue: #93 

This PR is an example of replacing `find_child()` use by [unique names](https://docs.godotengine.org/en/stable/tutorials/scripting/scene_unique_nodes.html).  

I'm listing positive and negative sides to help decide whenever is worth or not.  

Positive:
- It's possible to fast identify that you are dealing with a Node from the scene (because starts with "%" and it's green).  
- There is no need to create a variable (`var example: Control`) and later set it (`example = find_child()`).  
- While documentation mentioning `find_child()` being slow, it doesn't make that much diference because we are only using when setting the scene.  

Negative:
- Code completion only works when looking at scene and to make work even when not looking would require again setting a variable (`var example: Control`) or casting at runtime (`%Example as Control`).