### PR TITLE
Make set_global_position_popup not visible at start

### DIFF
--- a/addons/curved_lines_2d/set_global_position_popup_panel.gd
+++ b/addons/curved_lines_2d/set_global_position_popup_panel.gd
@@ -11,6 +11,7 @@ var _dragging := false
 var _drag_start := Vector2.ZERO
 
 func _enter_tree() -> void:
+	visible = false
 	x_pos_input = _mk_input()
 	y_pos_input = _mk_input()
 	%XPosInputContainer.add_child(x_pos_input)


### PR DESCRIPTION
Same reason as #90  

If somebody decide to look at the plugin scene, it will not make the popup appears every time.