### PR TITLE
Change imported SVGs to be named using PascalCase

### DIFF
--- a/addons/curved_lines_2d/svg_import_tab.gd
+++ b/addons/curved_lines_2d/svg_import_tab.gd
@@ -120,7 +120,7 @@ func _load_svg(file_path : String) -> void:
 
 	log_message("Importing SVG file: %s" % file_path, LogLevel.INFO)
 	var svg_root := Node2D.new()
-	svg_root.name = file_path.get_file().replace(".svg", "").capitalize()
+	svg_root.name = file_path.get_file().replace(".svg", "").to_pascal_case()
 	undo_redo.create_action("Import SVG file as Nodes: %s" % svg_root.name)
 	svg_root.position = _get_viewport_center()
 	svg_root.set_meta(SVG_ROOT_META_NAME, true)


### PR DESCRIPTION
Because Godot name convention for Nodes is PascalCase