### PR TITLE
Bugfix: stroke of a shape with a cutout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.30.2
+
+### Changed
+
+- Bugfix: the stroke of a shape with a cutout no longer runs straight across its own fill. A cutout can pinch the fill into a peninsula, which `slice_polygon_vertical` then cuts loose through its neck; `Geometry2DUtil.calculate_outlines` read the hole off a merged _pair_ of those slices, which still counted the peninsula as part of the cutout
+- A cutout enclosing an island of fill now gets a stroke drawn around that island as well: `Geometry2DUtil.calculate_outlines` returns it as a contour in its own right in stead of swallowing it
+
 ## 2.30.1
 
 ### Added

--- a/addons/curved_lines_2d/geometry_2d_util.gd
+++ b/addons/curved_lines_2d/geometry_2d_util.gd
@@ -193,8 +193,13 @@ static func _merge_until_stable(solids : Array[PackedVector2Array]) -> bool:
 # up into several polygons. Subtracting the overlapping ones first usually shrinks the
 # remainder far enough for the postponed ones to overlap it as well, so it can stay in
 # one piece. What is still enclosed once nothing else is left really is an island.
+# With [param slice_around_islands] flagged off the remainder is left whole and the
+# islands are returned alongside it, so both stay closed loops: a caller after the
+# _contours_ of the remainder needs them intact, a caller after its _surface_ needs it
+# sliced, because a [CollisionPolygon2D] cannot represent a hole.
 static func _subtract_polygons(minuend : PackedVector2Array,
-			subtrahends : Array[PackedVector2Array]) -> Array[PackedVector2Array]:
+			subtrahends : Array[PackedVector2Array],
+			slice_around_islands := true) -> Array[PackedVector2Array]:
 	var remainder : Array[PackedVector2Array] = [minuend]
 	var todo := subtrahends.duplicate()
 	while not todo.is_empty() and not remainder.is_empty():
@@ -213,6 +218,10 @@ static func _subtract_polygons(minuend : PackedVector2Array,
 			else:
 				remainder = difference
 		if postponed.size() == todo.size():
+			if not slice_around_islands:
+				# only islands are left: each of them bounds the remainder just like the
+				# remainder bounds them, so they are contours of it in their own right
+				return remainder + postponed
 			# only enclosed polygons are left: slice the remainder around them, in
 			# stead of leaving it with a hole it cannot represent
 			slice_polygons_with_holes(remainder, postponed)
@@ -221,41 +230,32 @@ static func _subtract_polygons(minuend : PackedVector2Array,
 	return remainder
 
 
-static func calculate_outlines(result : Array[PackedVector2Array]) -> Array[PackedVector2Array]:
-	if result.size() <= 1:
-		return result
-	var succesful_merges := true
-	var guard = 0
-	var holes : Array[PackedVector2Array] = []
-	while succesful_merges and result.size() > 1 and guard < 1000:
-		succesful_merges = false
-		guard += 1
-		var indices_to_be_removed : Dictionary[int, bool] = {}
-		var merged_to_be_appended : Array[PackedVector2Array] = []
+## Returns the contours enclosing the area covered by [param polygons]: the outline of
+## every solid they merge into first, followed by the holes those outlines enclose.
+## [ScalableVectorShape2D] draws one [Line2D] along each of them, so its stroke follows
+## the contour of a cutout just like it follows the contour of the shape itself.
+## The holes are derived from the merged outlines only once the whole set is joined,
+## because an area with a hole in it arrives here already sliced open around that hole -
+## see [method slice_polygons_with_holes]. Reading a hole off the merge of a _pair_ in
+## stead reports the hole of that pair: whatever the polygons merged after it fill up
+## of that hole is then still reported as a hole which is not there anymore.
+static func calculate_outlines(polygons : Array[PackedVector2Array]) -> Array[PackedVector2Array]:
+	if polygons.size() <= 1:
+		return polygons
 
-		for current_poly_idx in result.size():
-			if current_poly_idx in indices_to_be_removed:
+	var sources := polygons.duplicate()
+	_merge_until_stable(polygons)
+
+	var holes : Array[PackedVector2Array] = []
+	for solid in polygons:
+		for hole in _subtract_polygons(solid, sources, false):
+			if get_polygon_area(hole) <= MINIMUM_HOLE_AREA:
 				continue
-			for other_poly_idx in result.size():
-				if current_poly_idx == other_poly_idx or other_poly_idx in indices_to_be_removed:
-					continue
-				var merge_result := Geometry2D.merge_polygons(
-						result[current_poly_idx], result[other_poly_idx])
-				var regular := merge_result.filter(func(x): return not Geometry2D.is_polygon_clockwise(x))
-				var clockwise := merge_result.filter(Geometry2D.is_polygon_clockwise)
-				if regular.size() == 1:
-					succesful_merges = true
-					indices_to_be_removed[current_poly_idx] = true
-					indices_to_be_removed[other_poly_idx] = true
-					merged_to_be_appended.append(regular[0])
-					holes.append_array(clockwise)
-		var sorted_indices = indices_to_be_removed.keys()
-		sorted_indices.sort()
-		sorted_indices.reverse()
-		for idx in sorted_indices:
-			result.remove_at(idx)
-		result.append_array(merged_to_be_appended)
-	return result + holes
+			if not Geometry2D.is_polygon_clockwise(hole):
+				# a hole runs against the winding order of the outline enclosing it
+				hole.reverse()
+			holes.append(hole)
+	return polygons + holes
 
 
 static func calculate_polystroke(outline : PackedVector2Array, stroke_width : float,

--- a/addons/curved_lines_2d/tests/test_calculate_outlines.gd
+++ b/addons/curved_lines_2d/tests/test_calculate_outlines.gd
@@ -1,0 +1,132 @@
+extends SceneTree
+
+var failures := 0
+
+func _initialize() -> void:
+	test_cutout_keeps_its_own_contour()
+	test_peninsula_pinched_off_by_the_slice()
+	test_island_floating_inside_a_cutout()
+	test_shapes_which_do_not_touch()
+	print("")
+	print("FAILURES: ", failures)
+	quit(1 if failures > 0 else 0)
+
+
+func check(label : String, condition : bool, detail := "") -> void:
+	if condition:
+		print("  ok   - ", label, ("  (%s)" % detail) if detail else "")
+	else:
+		failures += 1
+		print("  FAIL - ", label, ("  (%s)" % detail) if detail else "")
+
+
+func area(poly : PackedVector2Array) -> float:
+	return Geometry2DUtil.get_polygon_area(poly)
+
+
+func ellipse_points(radius : float, offset := Vector2.ZERO) -> PackedVector2Array:
+	var c := Curve2D.new()
+	ScalableVectorShape2D.set_ellipse_points(c, Vector2(radius, radius) * 2.0)
+	var pts := c.tessellate(5, 1.0)
+	if pts[0].distance_to(pts[-1]) < 0.001:
+		pts.remove_at(pts.size() - 1)
+	var result : PackedVector2Array = []
+	for p in pts:
+		result.append(p + offset)
+	return result
+
+
+# Reproduces what _update_assigned_nodes_with_clips() feeds to calculate_outlines():
+# the fill after the cutouts were applied, already sliced open around its holes.
+func clipped_fill(fill : PackedVector2Array, cutouts : Array[PackedVector2Array]) -> Array[PackedVector2Array]:
+	return Geometry2DUtil.apply_clips_to_polygon([fill] as Array[PackedVector2Array], cutouts,
+			Geometry2D.PolyBooleanOperation.OPERATION_DIFFERENCE)
+
+
+func holes_of(contours : Array[PackedVector2Array]) -> Array[PackedVector2Array]:
+	return Array(contours.filter(Geometry2D.is_polygon_clockwise), TYPE_PACKED_VECTOR2_ARRAY, "", null)
+
+
+# Contours come out outline-first, but which hole lands where depends on the order the
+# polygons happened to merge in, so look them up by the surface they cover.
+func has_contour_covering(contours : Array[PackedVector2Array], expected : float) -> bool:
+	return contours.any(func(c : PackedVector2Array):
+			return absf(area(c) - expected) / expected < 0.02)
+
+
+# The stroke of a shape with a cutout is drawn along both of its contours, so the
+# cutout has to come back out of the sliced fill as one closed loop.
+func test_cutout_keeps_its_own_contour() -> void:
+	print("\n[1] round cutout in a round fill")
+	var clipped := clipped_fill(ellipse_points(100.0), [ellipse_points(40.0)] as Array[PackedVector2Array])
+	var contours := Geometry2DUtil.calculate_outlines(clipped.duplicate())
+	check("the fill arrives sliced in two", clipped.size() == 2, "%d polygons" % clipped.size())
+	check("one outline and one hole come out", contours.size() == 2, "%d contours" % contours.size())
+	check("exactly one of them is a hole", holes_of(contours).size() == 1)
+	var expected := PI * 100.0 * 100.0
+	check("the outline is the contour of the fill",
+			absf(area(contours[0]) - expected) / expected < 0.01,
+			"%.0f vs %.0f" % [area(contours[0]), expected])
+	expected = PI * 40.0 * 40.0
+	check("the hole is the contour of the cutout",
+			absf(area(contours[1]) - expected) / expected < 0.01,
+			"%.0f vs %.0f" % [area(contours[1]), expected])
+
+
+# A C-shaped cutout leaves a peninsula of fill sticking into it. slice_polygon_vertical()
+# cuts straight through the neck connecting it, so the fill arrives here as three
+# polygons of which two only touch along that cut. Merging a _pair_ of them reports the
+# hole of that pair, which still counts the peninsula as part of the cutout: reading the
+# holes off the intermediate merges draws the stroke straight across the fill.
+func test_peninsula_pinched_off_by_the_slice() -> void:
+	print("\n[2] cutout leaving a peninsula of fill")
+	var fill : PackedVector2Array = [
+		Vector2(0, 0), Vector2(400, 0), Vector2(400, 300), Vector2(0, 300)
+	]
+	# a "C" opening to the left: its mouth is the neck holding the peninsula
+	var cutout : PackedVector2Array = [
+		Vector2(100, 50), Vector2(300, 50), Vector2(300, 250), Vector2(100, 250),
+		Vector2(100, 200), Vector2(250, 200), Vector2(250, 100), Vector2(100, 100)
+	]
+	var clipped := clipped_fill(fill, [cutout] as Array[PackedVector2Array])
+	var contours := Geometry2DUtil.calculate_outlines(clipped.duplicate())
+	check("the slice separates the peninsula from the fill", clipped.size() == 3,
+			"%d polygons" % clipped.size())
+	check("one outline and one hole come out", contours.size() == 2, "%d contours" % contours.size())
+	check("the outline is the contour of the fill",
+			is_equal_approx(area(contours[0]), 120000.0), "%.0f vs 120000" % area(contours[0]))
+	check("the hole is the contour of the cutout, not its bounding shape",
+			is_equal_approx(area(contours[1]), 25000.0), "%.0f vs 25000" % area(contours[1]))
+	# the slice runs down the middle of the cutout's bounding box, at x = 200, so this
+	# is the piece of the peninsula it cuts loose from the rest of the fill
+	check("the piece of peninsula cut loose by the slice stays out of the hole",
+			not Geometry2D.is_point_in_polygon(Vector2(225, 150), contours[1]))
+	check("the cutout itself is inside the hole",
+			Geometry2D.is_point_in_polygon(Vector2(275, 150), contours[1]))
+
+
+# An island floating inside a cutout bounds the fill just like the cutout does, so it
+# is a contour of the shape in its own right and the stroke is drawn around it too.
+func test_island_floating_inside_a_cutout() -> void:
+	print("\n[3] island floating inside a cutout")
+	var clipped := clipped_fill(ellipse_points(100.0), [ellipse_points(40.0)] as Array[PackedVector2Array])
+	var with_island : Array[PackedVector2Array] = []
+	with_island.append_array(clipped)
+	with_island.append(ellipse_points(15.0))
+	var contours := Geometry2DUtil.calculate_outlines(with_island.duplicate())
+	check("outline, cutout and island all come out", contours.size() == 3,
+			"%d contours" % contours.size())
+	check("the island keeps its own contour",
+			has_contour_covering(contours, PI * 15.0 * 15.0))
+	check("the cutout is still the contour of the cutout",
+			has_contour_covering(contours, PI * 40.0 * 40.0))
+	check("the outline is still the contour of the fill",
+			has_contour_covering(contours, PI * 100.0 * 100.0))
+
+
+func test_shapes_which_do_not_touch() -> void:
+	print("\n[4] two shapes which do not touch")
+	var contours := Geometry2DUtil.calculate_outlines(
+			[ellipse_points(20.0), ellipse_points(20.0, Vector2(500, 0))] as Array[PackedVector2Array])
+	check("both are kept as an outline", contours.size() == 2, "%d contours" % contours.size())
+	check("neither is reported as a hole", holes_of(contours).is_empty())

--- a/addons/curved_lines_2d/tests/test_calculate_outlines.gd.uid
+++ b/addons/curved_lines_2d/tests/test_calculate_outlines.gd.uid
@@ -1,0 +1,1 @@
+uid://b4sfjoglmy34h


### PR DESCRIPTION
# Fix: the stroke of a shape with a cutout can be drawn straight across its own fill

## What happens

When a clip path cuts into a shape so that it pinches the fill into a **peninsula** — a
piece of fill still attached to the rest through a narrow neck — the `Line2D` drawn along
the contour of the cutout does not follow that contour. It takes a shortcut across the
fill, so the stroke is drawn *over* the shape in stead of *around* the hole.

| Before — the stroke runs straight across the fill | After — it follows the contour of the cutout |
| --- | --- |
| <img width="100%" alt="Before" src="https://github.com/user-attachments/assets/0fd589a7-4785-4ae3-a1cf-5d29dca74e22" /> | <img width="100%" alt="After" src="https://github.com/user-attachments/assets/8b72a317-09e4-40b3-a81a-8eb3b7e94300" /> |

The fill polygons themselves are fine — they cover the right area and none of them
self-intersects. Only the contours handed to the stroke are wrong, which is why this is
easy to miss: the shape looks correct until it has a stroke.

The regression test added here reproduces it with round numbers — a 400×300 rectangle
with a C-shaped cutout, whose mouth is the neck holding the peninsula:

| contour of the cutout | area |
| --- | --- |
| the cutout itself | **25000** |
| `calculate_outlines` before | 30000 |
| `calculate_outlines` after | **25000** |

The extra 5000 is the piece of peninsula that the slice cuts loose: the contour reported
as "the hole" swallows a solid piece of the fill, and the stroke is drawn along it.

Measured on the shape this was found on — a rounded blob with one concave, dart-shaped
clip path whose thin arm nearly strangles the fill:

| contour of the cutout | area | points |
| --- | --- | --- |
| `Geometry2D.clip_polygons(fill, clip)` — reference | **6177.1** | 52 |
| `calculate_outlines` — before | 6758.3 | 35 |
| `calculate_outlines` — after | **6177.1** | 56 |

6758.3 − 6177.1 = 581.2, which is exactly the surface of the peninsula the slice cut
loose (the sliced fill comes out as three rings of 581.2, 32242.7 and 34861.7).

## Why

`Polygon2D` cannot represent a hole, so `slice_polygons_with_holes` slices the clipped
fill open along a vertical line through the centre of the hole's bounding box. In these
shapes that line runs straight through the neck holding the peninsula, so the fill reaches
`calculate_outlines` as three polygons of which two only touch along that artificial cut.

`calculate_outlines` merged them pairwise and collected the holes reported by each
intermediate merge:

```
pass 1: merge(ring 0, ring 2) -> 1 outline, 1 hole   (correct for that pair)
pass 2: merge(ring 1, result) -> 1 outline, 0 holes
```

A merge only keeps `outlines[0]`, so what goes back into the accumulator is a solid
*without* its hole. By the time the peninsula is merged in and fills part of that hole
back up, the hole from pass 1 has already been archived and is never re-checked. The
stale, too-large hole is what the stroke ends up following.

This is the same shape of mistake the comment in `union_polygons` already warns about:

> a merge only reports the outline of the _pair_ it merged, so an area it enclosed may
> have been filled up by another polygon of the set

`union_polygons` was written to avoid it; `calculate_outlines` predates that and still
read the holes off the intermediate merges.

## The fix

`calculate_outlines` now derives the holes **once, from the merged outlines**, in stead
of off each intermediate merge — the approach `union_polygons` already uses:

```gdscript
var sources := polygons.duplicate()
_merge_until_stable(polygons)

var holes : Array[PackedVector2Array] = []
for solid in polygons:
	for hole in _subtract_polygons(solid, sources, false):
		...
```

`_subtract_polygons` gained one flag, `slice_around_islands`:

- `union_polygons` needs the remainder **sliced open** around an island, because a
  `CollisionPolygon2D` cannot represent a hole — unchanged, still the default.
- `calculate_outlines` needs the remainder **and** the island to stay **closed loops**,
  because a `Line2D` is drawn along each of them.

That second case is a bug fix of its own: an island of fill floating inside a cutout used
to be swallowed silently, so no stroke was drawn around it at all.

Net diff on `geometry_2d_util.gd`: +34 / −34. The old merge loop is replaced by the
already-tested `_merge_until_stable`, which also drops a latent staleness bug it had — it
kept merging into `result[current_poly_idx]` after that index was marked for removal,
where `_merge_until_stable` breaks out (`# solids[current_idx] is stale now`).

## Verification

`calculate_outlines` output on the four cases the new test covers:

| case | expected | before | after |
| --- | --- | --- | --- |
| round cutout in a round fill | outline + hole 5027 | ✅ | ✅ |
| **cutout pinching off a peninsula** | hole 25000 | ❌ 30000 | ✅ 25000 |
| **island floating inside a cutout** | island keeps a contour | ❌ lost | ✅ |
| two shapes which do not touch | two outlines, no holes | ✅ | ✅ |

End to end through the real clip-path pipeline — ten overlapping cutouts arranged in a
ring, so their union is an annulus and the middle of the fill is left as an island —
grading the resulting contour set against the true difference by even-odd nesting on
~10k sample points:

| | contours | misclassified |
| --- | --- | --- |
| before | 2 | 824 / 9940 (**8.29 %**) |
| after | 5 | 0 / 9940 (**0.00 %**) |

## Tests

New: `addons/curved_lines_2d/tests/test_calculate_outlines.gd` — 17 checks over four
cases. It fails with 4 failures on `master` and passes with the fix.

```
godot --headless --path . --script addons/curved_lines_2d/tests/test_calculate_outlines.gd
```

The existing suites are unaffected:

| suite | result |
| --- | --- |
| `test_calculate_outlines.gd` (new) | FAILURES: 0 |
| `test_union_polygons.gd` | FAILURES: 0 |
| `test_collision_mode.gd` | FAILURES: 0 |

Tested on Godot 4.4.stable (the branch this targets) and on 4.7.1.stable.

## Not in this PR

Two things I ran into while tracking this down, left alone on purpose:

1. **The slice line is a heuristic.** `slice_polygon_vertical` cuts at the centre of the
   hole's *bounding box*, which is what ran through the peninsula's neck here. When two
   holes have nearly the same bounding-box centre it also produces sub-pixel slivers —
   `CollisionPolygon2D` nodes about 0.04 px wide, which make Godot log
   `Convex decomposing failed!` on load. Choosing the cut where the shape is narrowest, or
   slicing along the axis with the shorter span, would be more robust, but that is a
   change in behaviour rather than a fix.
2. **Surplus `CollisionPolygon2D` nodes are kept hidden and disabled** for reuse (as
   documented in `_update_collision_polygons`). They stay in the saved scene and the
   engine still decomposes them at load, so old slivers keep producing those errors even
   after the shape recomputes to fewer colliders.
