### PR TITLE
FIX #396: errors from editor

### DIFF
--- a/addons/curved_lines_2d/curved_lines_2d.gd
+++ b/addons/curved_lines_2d/curved_lines_2d.gd
@@ -1287,10 +1287,10 @@ func _handle_brush_draw(viewport_control : Control) -> void:
 				PaintOrder.MARKERS_STROKE_FILL, PaintOrder.STROKE_FILL_MARKERS, PaintOrder.STROKE_MARKERS_FILL:
 					if _is_add_stroke_enabled():
 						viewport_control.draw_polyline(pts, _get_default_stroke_color(), _get_default_stroke_width() * EditorInterface.get_editor_viewport_2d().get_final_transform().get_scale().x, true)
-					if _is_add_fill_enabled():
+					if _is_add_fill_enabled() and _can_be_filled(pts):
 						viewport_control.draw_polygon(pts, [_get_default_fill_color()])
 				PaintOrder.MARKERS_FILL_STROKE, PaintOrder.FILL_STROKE_MARKERS, PaintOrder.FILL_MARKERS_STROKE, _:
-					if _is_add_fill_enabled():
+					if _is_add_fill_enabled() and _can_be_filled(pts):
 						viewport_control.draw_polygon(pts, [_get_default_fill_color()])
 					if _is_add_stroke_enabled():
 						viewport_control.draw_polyline(pts, _get_default_stroke_color(), _get_default_stroke_width() * EditorInterface.get_editor_viewport_2d().get_final_transform().get_scale().x, true)
@@ -1305,7 +1305,7 @@ func _handle_brush_draw(viewport_control : Control) -> void:
 		var pts := Array(Geometry2DUtil.get_polygon_at_granularity(_current_brush_shape,
 				_get_guarded_brush_granularity()
 		)).map(func(p): return _vp_transform(p * Transform2D(mul.get_rotation(), mul.get_scale(), 0.0, Vector2.ZERO) + mouse_pos))
-		if _is_add_fill_enabled():
+		if _is_add_fill_enabled() and _can_be_filled(pts):
 			viewport_control.draw_polygon(pts, [_get_default_fill_color()])
 		else:
 			viewport_control.draw_polyline(pts, Color.LIME)
@@ -1447,10 +1447,10 @@ func _forward_canvas_draw_over_viewport(viewport_control: Control) -> void:
 			PaintOrder.MARKERS_STROKE_FILL, PaintOrder.STROKE_FILL_MARKERS, PaintOrder.STROKE_MARKERS_FILL:
 				if _is_add_stroke_enabled():
 					viewport_control.draw_polyline(stroke_points, _get_default_stroke_color(), stroke_width)
-				if _is_add_fill_enabled():
+				if _is_add_fill_enabled() and _can_be_filled(points):
 					viewport_control.draw_polygon(points, [_get_default_fill_color()])
 			PaintOrder.MARKERS_FILL_STROKE, PaintOrder.FILL_STROKE_MARKERS, PaintOrder.FILL_MARKERS_STROKE, _:
-				if _is_add_fill_enabled():
+				if _is_add_fill_enabled() and _can_be_filled(points):
 					viewport_control.draw_polygon(points, [_get_default_fill_color()])
 				if _is_add_stroke_enabled():
 					viewport_control.draw_polyline(stroke_points, _get_default_stroke_color(), stroke_width)
@@ -2958,3 +2958,12 @@ func _exit_tree():
 	remove_control_from_bottom_panel(scalable_vector_shapes_2d_dock)
 	scalable_vector_shapes_2d_dock.free()
 	set_global_position_popup_panel.free()
+
+
+# draw_polygon() triangulates whatever it is handed and reports
+# "Invalid polygon data, triangulation failed." when it cannot. A shape dragged across
+# itself is self-intersecting for as long as the drag lasts, so the preview of its fill
+# cannot be drawn during those frames - skip it in stead of logging an error per frame.
+# The outline is drawn by draw_polyline() either way, which needs no triangulation.
+static func _can_be_filled(points) -> bool:
+	return Geometry2D.triangulate_polygon(PackedVector2Array(points)).size() > 0

--- a/addons/curved_lines_2d/geometry_2d_util.gd
+++ b/addons/curved_lines_2d/geometry_2d_util.gd
@@ -40,6 +40,134 @@ static func get_polygon_area(points : PackedVector2Array) -> float:
 	return absf(double_area) * 0.5
 
 
+## Removes every vertex coinciding with the one before it, the closing vertex included.
+## The boolean operations of [Geometry2D] hand back contours in which the same point
+## occurs twice in a row - a corner where two clipped edges meet, most often. That is
+## the same shape geometrically, but Godot cannot triangulate it: a [CollisionPolygon2D]
+## carrying such a contour makes `decompose_polygon_in_convex()` bail out with
+## `Convex decomposing failed!` every time the scene loads and every time the shape is
+## recomputed, even when the node is hidden and disabled.
+static func remove_duplicate_points(points : PackedVector2Array) -> PackedVector2Array:
+	var result : PackedVector2Array = []
+	for p : Vector2 in points:
+		if result.is_empty() or not result[-1].is_equal_approx(p):
+			result.append(p)
+	while result.size() > 1 and result[0].is_equal_approx(result[-1]):
+		result.remove_at(result.size() - 1)
+	return result
+
+
+## Returns the simple polygon(s) covering the surface enclosed by [param points].
+## A contour that crosses itself - a shape dragged through itself, a clip path folded
+## over its own outline - cannot be triangulated, so neither [Polygon2D] nor
+## [CollisionPolygon2D] can digest it: the editor logs
+## `Invalid polygon data, triangulation failed.` on every redraw and the collider
+## `Convex decomposing failed!` on every rebuild, for as long as the contour stays.
+## Merging such a contour with itself resolves the crossings into one simple outline
+## per enclosed lobe. A contour that is already simple comes back alone, deduplicated;
+## one enclosing no surface at all comes back as nothing.
+static func normalize_contour(points : PackedVector2Array) -> Array[PackedVector2Array]:
+	var cleaned := remove_duplicate_points(points)
+	if cleaned.size() < 3:
+		return []
+	if not Geometry2D.triangulate_polygon(cleaned).is_empty():
+		return [cleaned]
+	var pieces : Array[PackedVector2Array] = []
+	for piece in Geometry2D.merge_polygons(cleaned, cleaned):
+		if Geometry2D.is_polygon_clockwise(piece):
+			continue
+		# the merge can hand a weakly simple contour straight back - lobes pinched
+		# together at a repeated vertex - which not even ear clipping digests reliably
+		for loop in split_at_pinch_points(remove_duplicate_points(piece)):
+			if loop.size() > 2 and not Geometry2D.triangulate_polygon(loop).is_empty():
+				pieces.append(loop)
+	# what is left after this are sub-pixel artefacts of the merge itself - Clipper
+	# works on scaled integers and can return a micro-crossing unchanged - and nothing
+	# that draws or collides can digest those: they are dropped, not handed on
+	return pieces
+
+
+## Whether no two non-adjacent edges of the contour touch: no crossings, and no vertex
+## resting on a foreign edge. Ear clipping tolerates a surprising amount of both, so a
+## contour can triangulate and still be rejected by the convex partitioner that builds
+## a [CollisionPolygon2D]'s shapes - which prints `Convex decomposing failed!` when it
+## gives up. This is the silent test for what that partitioner will accept.
+static func is_strictly_simple(points : PackedVector2Array, tolerance := 0.001) -> bool:
+	var n := points.size()
+	for i in n:
+		var a1 := points[i]
+		var a2 := points[(i + 1) % n]
+		for j in range(i + 1, n):
+			if j == i + 1 or (i == 0 and j == n - 1):
+				continue
+			var b1 := points[j]
+			var b2 := points[(j + 1) % n]
+			if Geometry2D.segment_intersects_segment(a1, a2, b1, b2) != null:
+				return false
+			if Geometry2D.get_closest_point_to_segment(b1, a1, a2).distance_to(b1) < tolerance:
+				return false
+			if Geometry2D.get_closest_point_to_segment(a1, b1, b2).distance_to(a1) < tolerance:
+				return false
+	return true
+
+
+## Removes every vertex lying sub-pixel close to the straight edge between its two
+## neighbours. The vertical cut of [method slice_polygons_with_holes] leaves such
+## vertices along both halves of the cut edge and re-merging keeps them: harmless to
+## the shape itself, but the convex partition of a [CollisionPolygon2D] can emit a
+## zero-area piece at one - which decomposes without complaint and then fails to draw,
+## logging `Invalid polygon data, triangulation failed.` on every editor redraw with
+## no failing decomposition in sight.
+static func remove_collinear_points(points : PackedVector2Array, tolerance := 0.01) -> PackedVector2Array:
+	if points.size() < 4:
+		return points
+	var result : PackedVector2Array = []
+	for i in points.size():
+		var previous := points[(i - 1 + points.size()) % points.size()]
+		var next := points[(i + 1) % points.size()]
+		var on_edge := Geometry2D.get_closest_point_to_segment(points[i], previous, next)
+		if on_edge.distance_to(points[i]) >= tolerance:
+			result.append(points[i])
+	return result if result.size() > 2 else points
+
+
+## Splits a contour that touches itself at a repeated - but not consecutive - vertex
+## into the separate loops meeting there, recursively. Clipper hands back such "weakly
+## simple" contours whenever a union pinches two lobes together at a point: the
+## ear-clipping triangulator accepts them, but the convex partitioner that builds a
+## [CollisionPolygon2D]'s shapes does not, and reports `Convex decomposing failed!` on
+## every physics rebuild. Each loop keeps one copy of the shared vertex, so together
+## they cover exactly the surface of the original.
+static func split_at_pinch_points(points : PackedVector2Array) -> Array[PackedVector2Array]:
+	for i in points.size():
+		for j in range(i + 1, points.size()):
+			if points[i].is_equal_approx(points[j]):
+				var inner := points.slice(i, j)
+				var outer := points.slice(j) + points.slice(0, i)
+				return split_at_pinch_points(inner) + split_at_pinch_points(outer)
+	return [points]
+
+
+## [method normalize_contour] applied to a whole set: the pieces of every contour, flat.
+static func normalize_contours(polygons : Array[PackedVector2Array]) -> Array[PackedVector2Array]:
+	var result : Array[PackedVector2Array] = []
+	for points in polygons:
+		result.append_array(normalize_contour(points))
+	return result
+
+
+## The contour of [param polygons] covering the largest surface; empty when none does.
+static func largest_contour(polygons : Array[PackedVector2Array]) -> PackedVector2Array:
+	var best : PackedVector2Array = []
+	var best_area := 0.0
+	for points in polygons:
+		var area := get_polygon_area(points)
+		if area > best_area:
+			best_area = area
+			best = points
+	return best
+
+
 static func slice_polygon_vertical(polygon : PackedVector2Array, slice_target : Vector2) -> Array[PackedVector2Array]:
 	var box := get_polygon_bounding_rect(polygon).grow(1.0)
 	if not box.has_point(slice_target):

--- a/addons/curved_lines_2d/scalable_vector_shape_2d.gd
+++ b/addons/curved_lines_2d/scalable_vector_shape_2d.gd
@@ -85,6 +85,13 @@ enum StrokeExtrusionDirection {
 
 ## Determines which area the [CollisionPolygon2D] nodes generated for the
 ## [member collision_object] cover, see [member collision_mode]
+## The surface below which a contour is not worth a [CollisionPolygon2D]: at this scale
+## it is an artefact of a boolean operation rather than a piece of shape - a collider
+## 0.3 px across collides with nothing, and Godot cannot triangulate it to draw it in
+## the editor. Same order of magnitude as [constant Geometry2DUtil.MINIMUM_HOLE_AREA].
+const MINIMUM_COLLISION_AREA := 0.1
+
+
 enum CollisionMode {
 	## Generates the smallest possible set of [CollisionPolygon2D] nodes covering the
 	## fill and the stroke as one single area, in stead of one set per shape.
@@ -829,16 +836,30 @@ func _update_assigned_nodes(polygon_points : PackedVector2Array) -> void:
 		line.closed = is_curve_closed()
 	if is_instance_valid(poly_stroke):
 		var polygon_indices : Array = []
-		var poly := Geometry2DUtil.get_polygon_indices(cached_poly_strokes, polygon_indices)
+		var poly := Geometry2DUtil.get_polygon_indices(
+				Geometry2DUtil.normalize_contours(cached_poly_strokes), polygon_indices)
 		poly_stroke.polygon = poly
 		poly_stroke.polygons = polygon_indices
 		_update_polygon_texture(poly_stroke, true)
 	if is_instance_valid(polygon):
+		var fill_contours := Geometry2DUtil.normalize_contour(polygon_points)
 		polygon.polygons.clear()
-		polygon.polygon = polygon_points
+		if fill_contours.size() > 1:
+			# the outline crosses itself: fill each lobe as a contour of its own,
+			# in stead of handing Polygon2D a shape it cannot triangulate
+			var fill_indices : Array = []
+			polygon.polygon = Geometry2DUtil.get_polygon_indices(fill_contours, fill_indices)
+			polygon.polygons = fill_indices
+		elif not fill_contours.is_empty():
+			polygon.polygon = fill_contours[0]
+		else:
+			# nothing drawable in this contour: park the node empty in stead of handing
+			# it a polygon it will fail to triangulate on every redraw
+			polygon.polygon = polygon_points if polygon_points.size() < 3 else PackedVector2Array()
 		_update_polygon_texture()
 	if is_instance_valid(collision_polygon):
-		collision_polygon.polygon = polygon_points
+		collision_polygon.polygon = Geometry2DUtil.largest_contour(
+				_collidable_contours([polygon_points]))
 	if is_instance_valid(collision_object):
 		var fill_polygons : Array[PackedVector2Array] = [polygon_points]
 		_update_collision_polygons(_get_collision_polygons(fill_polygons))
@@ -890,14 +911,17 @@ func _update_assigned_nodes_with_clips(polygon_points : PackedVector2Array, vali
 	var clips := valid_clip_paths.filter(func(cp : ScalableVectorShape2D): return cp.use_interect_when_clipping)
 	var cutouts := valid_clip_paths.filter(func(cp : ScalableVectorShape2D): return not cp.use_interect_when_clipping and not cp.use_union_in_stead_of_clipping)
 
+	# a self-crossing outline - the shape's own or a clip path's - would poison every
+	# boolean operation below and end up on nodes that cannot triangulate it, so each
+	# contour is resolved into simple pieces before it enters the pipeline
 	var merge_results := Geometry2DUtil.apply_clips_to_polygon(
-		[polygon_points],
-		Array(merges.map(_clip_path_to_local), TYPE_PACKED_VECTOR2_ARRAY, "", null),
+		Geometry2DUtil.normalize_contour(polygon_points),
+		Geometry2DUtil.normalize_contours(Array(merges.map(_clip_path_to_local), TYPE_PACKED_VECTOR2_ARRAY, "", null)),
 		Geometry2D.PolyBooleanOperation.OPERATION_UNION
 	)
 	var cutout_results := Geometry2DUtil.apply_clips_to_polygon(
 		merge_results,
-		Array(cutouts.map(_clip_path_to_local), TYPE_PACKED_VECTOR2_ARRAY, "", null),
+		Geometry2DUtil.normalize_contours(Array(cutouts.map(_clip_path_to_local), TYPE_PACKED_VECTOR2_ARRAY, "", null)),
 		Geometry2D.PolyBooleanOperation.OPERATION_DIFFERENCE
 	)
 
@@ -917,13 +941,13 @@ func _update_assigned_nodes_with_clips(polygon_points : PackedVector2Array, vali
 			))
 		intersect_results_polystroke = Geometry2DUtil.apply_clips_to_polygon(
 			polystroke_result,
-			Array(clips.map(_clip_path_to_local), TYPE_PACKED_VECTOR2_ARRAY, "", null),
+			Geometry2DUtil.normalize_contours(Array(clips.map(_clip_path_to_local), TYPE_PACKED_VECTOR2_ARRAY, "", null)),
 			Geometry2D.PolyBooleanOperation.OPERATION_INTERSECTION
 		)
 
 	var intersect_results_fill_polygon := Geometry2DUtil.apply_clips_to_polygon(
 		cutout_results,
-		Array(clips.map(_clip_path_to_local), TYPE_PACKED_VECTOR2_ARRAY, "", null),
+		Geometry2DUtil.normalize_contours(Array(clips.map(_clip_path_to_local), TYPE_PACKED_VECTOR2_ARRAY, "", null)),
 		Geometry2D.PolyBooleanOperation.OPERATION_INTERSECTION
 	)
 
@@ -967,7 +991,8 @@ func _update_assigned_nodes_with_clips(polygon_points : PackedVector2Array, vali
 		else:
 			poly_stroke.show()
 			var polygon_indices : Array = []
-			var poly := Geometry2DUtil.get_polygon_indices(cached_poly_strokes, polygon_indices)
+			var poly := Geometry2DUtil.get_polygon_indices(
+					Geometry2DUtil.normalize_contours(cached_poly_strokes), polygon_indices)
 			poly_stroke.polygon = poly
 			poly_stroke.polygons = polygon_indices
 			_update_polygon_texture(poly_stroke, true)
@@ -977,12 +1002,16 @@ func _update_assigned_nodes_with_clips(polygon_points : PackedVector2Array, vali
 		else:
 			polygon.show()
 			var polygon_indices : Array = []
-			var poly := Geometry2DUtil.get_polygon_indices(cached_clipped_polygons, polygon_indices)
+			# the boolean pipeline can still hand back a piece the triangulator
+			# rejects - resolve those before Polygon2D has to draw them
+			var poly := Geometry2DUtil.get_polygon_indices(
+					Geometry2DUtil.normalize_contours(cached_clipped_polygons), polygon_indices)
 			polygon.polygon = poly
 			polygon.polygons = polygon_indices
 			_update_polygon_texture()
 	if is_instance_valid(collision_polygon):
-		collision_polygon.polygon = polygon_points
+		collision_polygon.polygon = Geometry2DUtil.largest_contour(
+				_collidable_contours([polygon_points]))
 	if is_instance_valid(collision_object):
 		_update_collision_polygons(_get_collision_polygons(cached_clipped_polygons))
 
@@ -1023,17 +1052,101 @@ func _get_fill_and_stroke_polygons(fill_polygons : Array[PackedVector2Array]) ->
 # Any surplus node is kept, but hidden and disabled, so it can be reused when the
 # amount of polygons grows again
 func _update_collision_polygons(collision_polygons : Array[PackedVector2Array]) -> void:
+	var usable := _collidable_contours(collision_polygons)
 	var existing = collision_object.get_children().filter(func(ch): return ch is CollisionPolygon2D)
 	for idx in existing.size():
-		if idx >= collision_polygons.size():
+		if idx >= usable.size():
 			existing[idx].hide()
 			existing[idx].disabled = true
-	for polygon_index in collision_polygons.size():
+			# a stale contour would keep failing convex decomposition on every physics
+			# rebuild - hidden and disabled or not - so the node is parked empty until
+			# it is reused (or pruned before save)
+			existing[idx].polygon = PackedVector2Array()
+	for polygon_index in usable.size():
 		if polygon_index >= existing.size():
 			existing.append(_make_new_collision_polygon_2d())
-		existing[polygon_index].polygon = collision_polygons[polygon_index]
+		existing[polygon_index].polygon = usable[polygon_index]
 		existing[polygon_index].show()
 		existing[polygon_index].disabled = false
+
+
+# Not every contour is worth a CollisionPolygon2D as it arrives:
+#  - one with a vertex repeating the one before it cannot be decomposed into convex
+#    shapes, which Godot reports as `Convex decomposing failed!` on load;
+#  - one that crosses itself cannot either, and the editor cannot triangulate it to
+#    draw it, adding `Invalid polygon data, triangulation failed.` on every redraw -
+#    it is resolved into its simple pieces in stead (see normalize_contour);
+#  - one that touches itself at a repeated vertex - a union pinching two lobes
+#    together - triangulates but does not decompose either, and is split into the
+#    separate loops meeting there (see split_at_pinch_points);
+#  - one enclosing next to no surface collides with nothing and is dropped.
+func _collidable_contours(contours : Array[PackedVector2Array]) -> Array[PackedVector2Array]:
+	var usable : Array[PackedVector2Array] = []
+	for contour in contours:
+		for piece in Geometry2DUtil.normalize_contour(contour):
+			for raw_loop in Geometry2DUtil.split_at_pinch_points(piece):
+				# the slice line leaves collinear vertices along the cut: the convex
+				# partition emits a zero-area piece at each, which the editor then
+				# fails to draw - see remove_collinear_points
+				var loop := Geometry2DUtil.remove_collinear_points(raw_loop)
+				if Geometry2DUtil.get_polygon_area(loop) <= MINIMUM_COLLISION_AREA:
+					continue
+				if Geometry2D.triangulate_polygon(loop).is_empty():
+					# still not drawable after normalization: a sub-pixel artefact
+					continue
+				if not Geometry2DUtil.is_strictly_simple(loop):
+					# ear clipping tolerated its crossings, the convex partitioner
+					# will not: resolve them silently in stead of letting the
+					# partitioner print - once more through Clipper, then give up
+					_append_resolved_collidable_loops(loop, usable)
+					continue
+				if not _decomposes_into_drawable_pieces(loop):
+					continue
+				usable.append(loop)
+	return usable
+
+
+# One silent resolution attempt for a loop that triangulates but is not strictly
+# simple: merging it with itself makes Clipper resolve the crossings. What comes
+# back is held to every gate again; what still fails is dropped without a node -
+# never handed to the partitioner, which would print `Convex decomposing failed!`.
+func _append_resolved_collidable_loops(loop : PackedVector2Array,
+			usable : Array[PackedVector2Array]) -> void:
+	for piece in Geometry2D.merge_polygons(loop, loop):
+		if Geometry2D.is_polygon_clockwise(piece):
+			continue
+		for sub in Geometry2DUtil.split_at_pinch_points(
+				Geometry2DUtil.remove_duplicate_points(piece)):
+			var cleaned := Geometry2DUtil.remove_collinear_points(sub)
+			if cleaned.size() < 3:
+				continue
+			if Geometry2DUtil.get_polygon_area(cleaned) <= MINIMUM_COLLISION_AREA:
+				continue
+			if Geometry2D.triangulate_polygon(cleaned).is_empty():
+				continue
+			if not Geometry2DUtil.is_strictly_simple(cleaned):
+				continue
+			if not _decomposes_into_drawable_pieces(cleaned):
+				continue
+			usable.append(cleaned)
+
+
+# The exact criterion the editor applies when it draws a CollisionPolygon2D: convex
+# decomposition, then a triangulated fill per piece. A sliver left over from booleans -
+# a band a fraction of a pixel wide between the stroke and the fill it hugs, as
+# described in #396 - can pass every contour-level check and still decompose into
+# near-zero pieces the fill rejects, logging `Invalid polygon data` on every redraw.
+# The decompose call is silent whenever it succeeds; the gates above make the failing
+# (printing) case all but impossible, and a contour that fails it here is dropped, so
+# it prints once per recompute at worst - never once per redraw.
+func _decomposes_into_drawable_pieces(loop : PackedVector2Array) -> bool:
+	var pieces := Geometry2D.decompose_polygon_in_convex(loop)
+	if pieces.is_empty():
+		return false
+	for piece in pieces:
+		if Geometry2D.triangulate_polygon(piece).is_empty():
+			return false
+	return true
 
 
 func _make_new_collision_polygon_2d() -> CollisionPolygon2D:

--- a/addons/curved_lines_2d/tests/test_collision_contours.gd
+++ b/addons/curved_lines_2d/tests/test_collision_contours.gd
@@ -1,0 +1,185 @@
+extends SceneTree
+
+# Reproduces both errors a contour can provoke once it reaches a CollisionPolygon2D.
+#
+# [1]-[4] `Convex decomposing failed!`, reported in #398 and #396.
+#
+# The boolean operations of Geometry2D hand back contours in which a vertex occurs twice
+# in a row. The shape is the same - a zero length edge covers no surface - but Godot's
+# triangulator cannot handle it: decompose_polygon_in_convex() bails out, which is what
+# a CollisionPolygon2D calls when it builds its shapes. The error is logged every time
+# the scene loads and every time the shape is recomputed, whether the node is enabled or
+# hidden and disabled.
+#
+# _update_assigned_nodes() already dropped the closing vertex when it coincided with the
+# first one; the duplicates in the middle of the contour are the ones that got through.
+#
+# [5] `Invalid polygon data, triangulation failed.`
+#
+# A boolean operation can also hand back a contour enclosing no surface at all. It is
+# not a collider - it collides with nothing - and it cannot be triangulated, which the
+# editor does to every CollisionPolygon2D in order to draw it. The result is that error
+# on every single redraw, for as long as the node exists.
+
+var failures := 0
+
+
+# CollisionPolygon2D10 of a shape with two overlapping cutouts, read straight out of the
+# saved scene. Three of its seventeen vertices repeat the one before them.
+var from_a_saved_scene := PackedVector2Array([
+	Vector2(286.457000732422, 200.233993530273), Vector2(281.188995361328, 196.292007446289),
+	Vector2(275.733001708984, 192.207992553711), Vector2(275.639007568359, 192.121994018555),
+	Vector2(266.139007568359, 183.363998413086), Vector2(266.139007568359, 140.733993530273),
+	Vector2(268.255004882813, 140.287994384766), Vector2(268.390014648438, 140.259002685547),
+	Vector2(268.528015136719, 140.246002197266), Vector2(268.528015136719, 140.246002197266),
+	Vector2(278.819000244141, 139.238998413086), Vector2(278.819000244141, 139.238998413086),
+	Vector2(278.912994384766, 139.229995727539), Vector2(279.007995605469, 139.227996826172),
+	Vector2(279.007995605469, 139.227996826172), Vector2(281.188995361328, 139.180999755859),
+	Vector2(286.457000732422, 139.067001342773),
+])
+
+
+func _initialize() -> void:
+	test_a_contour_from_a_saved_scene()
+	test_a_single_repeat_is_tolerated()
+	test_a_clean_contour_is_left_alone()
+	test_the_closing_vertex_is_dropped()
+	test_contours_without_surface_get_no_collider()
+	test_a_self_crossing_contour_is_resolved_into_lobes()
+	print("")
+	print("FAILURES: ", failures)
+	quit(1 if failures > 0 else 0)
+
+
+func check(label : String, condition : bool, detail := "") -> void:
+	if condition:
+		print("  ok   - ", label, ("  (%s)" % detail) if detail else "")
+	else:
+		failures += 1
+		print("  FAIL - ", label, ("  (%s)" % detail) if detail else "")
+
+
+func decomposes(poly : PackedVector2Array) -> bool:
+	return not Geometry2D.decompose_polygon_in_convex(poly).is_empty()
+
+
+func area(poly : PackedVector2Array) -> float:
+	return Geometry2DUtil.get_polygon_area(poly)
+
+
+# The case as it comes out of the plugin: a CollisionPolygon2D which logs an error on
+# every load, and keeps logging it while hidden and disabled.
+func test_a_contour_from_a_saved_scene() -> void:
+	print("\n[1] a contour of a cutout, read out of a saved scene")
+	var cleaned := Geometry2DUtil.remove_duplicate_points(from_a_saved_scene)
+	check("three vertices repeat the one before them",
+			from_a_saved_scene.size() - cleaned.size() == 3,
+			"%d -> %d points" % [from_a_saved_scene.size(), cleaned.size()])
+	check("Godot cannot decompose it as saved", not decomposes(from_a_saved_scene))
+	check("it decomposes once the repeats are gone", decomposes(cleaned))
+	check("the surface it covers is unchanged",
+			absf(area(cleaned) - area(from_a_saved_scene)) < 0.000001,
+			"%.6f vs %.6f" % [area(cleaned), area(from_a_saved_scene)])
+
+
+# Why this is so hard to reproduce by hand: a repeated vertex on a shape you can draw is
+# tolerated. The triangulator only gives up on contours that come out of overlapping
+# cutouts, and only once several repeats accumulated in one of them - dropping a single
+# repeat out of the three is not enough, which is why the whole contour has to be swept.
+func test_a_single_repeat_is_tolerated() -> void:
+	print("
+[2] a repeat is only fatal in combination")
+	var square := PackedVector2Array([Vector2(0, 0), Vector2(100, 0), Vector2(100, 0),
+			Vector2(100, 100), Vector2(0, 100)])
+	check("a square with a repeated vertex still decomposes", decomposes(square))
+	var l_shape := PackedVector2Array([Vector2(0, 0), Vector2(100, 0), Vector2(100, 50),
+			Vector2(50, 50), Vector2(50, 50), Vector2(50, 100), Vector2(0, 100)])
+	check("so does a concave one", decomposes(l_shape))
+	for index in [9, 11, 14]:
+		var one_less := from_a_saved_scene.duplicate()
+		one_less.remove_at(index)
+		check("dropping only the repeat at %d does not save the real contour" % index,
+				not decomposes(one_less))
+	check("dropping all three does",
+			decomposes(Geometry2DUtil.remove_duplicate_points(from_a_saved_scene)))
+
+
+# The fix may not touch contours which are already fine: no vertex is dropped for being
+# merely close to its neighbour.
+func test_a_clean_contour_is_left_alone() -> void:
+	print("\n[3] a contour without repeats")
+	var poly := PackedVector2Array([Vector2(0, 0), Vector2(0.01, 0), Vector2(100, 0.02),
+			Vector2(100, 100), Vector2(0, 100)])
+	var cleaned := Geometry2DUtil.remove_duplicate_points(poly)
+	check("every vertex survives", cleaned == poly, "%d -> %d points" % [poly.size(), cleaned.size()])
+
+
+# The closing vertex is a repeat of the first one, one lap further along.
+func test_the_closing_vertex_is_dropped() -> void:
+	print("\n[4] a contour closed by repeating its first vertex")
+	var closed := PackedVector2Array([Vector2(0, 0), Vector2(100, 0), Vector2(100, 100),
+			Vector2(0, 100), Vector2(0, 0)])
+	var cleaned := Geometry2DUtil.remove_duplicate_points(closed)
+	check("the closing vertex is dropped", cleaned.size() == 4, "%d points" % cleaned.size())
+	check("the surface is unchanged", is_equal_approx(area(cleaned), 10000.0), "%.1f" % area(cleaned))
+
+
+# A contour with no surface never becomes a CollisionPolygon2D, and the repeats are swept
+# out of the ones that do.
+func test_contours_without_surface_get_no_collider() -> void:
+	print("
+[5] contours which do not deserve a collider")
+	var shape := ScalableVectorShape2D.new()
+	var square := PackedVector2Array([Vector2(0, 0), Vector2(100, 0), Vector2(100, 100),
+			Vector2(0, 100)])
+	var collinear := PackedVector2Array([Vector2(0, 0), Vector2(50, 0), Vector2(100, 0)])
+	var pinched := PackedVector2Array([Vector2(0, 0), Vector2(100, 0), Vector2(0, 0),
+			Vector2(100, 0), Vector2(0, 0)])
+	var contours : Array[PackedVector2Array] = [square, collinear, pinched,
+			from_a_saved_scene]
+	var usable := shape._collidable_contours(contours)
+	check("the two contours with surface survive", usable.size() == 2,
+			"%d of %d kept" % [usable.size(), contours.size()])
+	check("the collinear triangle is dropped", not usable.has(collinear))
+	check("the pinched contour is dropped", not usable.has(pinched))
+	for contour in usable:
+		check("what is kept triangulates: %d pts" % contour.size(),
+				not Geometry2D.triangulate_polygon(contour).is_empty())
+	check("the square keeps its surface",
+			is_equal_approx(Geometry2DUtil.get_polygon_area(usable[0]), 10000.0),
+			"%.1f" % Geometry2DUtil.get_polygon_area(usable[0]))
+	shape.free()
+
+
+# A shape dragged through itself encloses real surface but cannot be triangulated as it
+# stands. normalize_contour() resolves the crossing into simple geometry - how many
+# pieces come out is Clipper's business (lobes sharing only the crossing point can come
+# back as a single self-touching contour) - so the fill and the colliders get geometry
+# they can digest for every frame of the drag, covering the same surface.
+func test_a_self_crossing_contour_is_resolved_into_lobes() -> void:
+	print("
+[6] a self-crossing contour with real surface")
+	var figure_of_eight := PackedVector2Array([Vector2(0, 0), Vector2(100, 100),
+			Vector2(100, 0), Vector2(0, 100)])
+	check("as one contour it does not triangulate",
+			Geometry2D.triangulate_polygon(figure_of_eight).is_empty())
+	var pieces := Geometry2DUtil.normalize_contour(figure_of_eight)
+	check("it resolves into simple geometry", not pieces.is_empty(), "%d pieces" % pieces.size())
+	var total := 0.0
+	for piece in pieces:
+		check("piece of %d pts triangulates" % piece.size(),
+				not Geometry2D.triangulate_polygon(piece).is_empty())
+		total += Geometry2DUtil.get_polygon_area(piece)
+	check("together they cover both lobes", is_equal_approx(total, 5000.0), "%.1f" % total)
+	var square := PackedVector2Array([Vector2(0, 0), Vector2(100, 0), Vector2(100, 100),
+			Vector2(0, 100)])
+	var untouched := Geometry2DUtil.normalize_contour(square)
+	check("a simple contour comes back alone", untouched.size() == 1 and untouched[0] == square)
+	var shape := ScalableVectorShape2D.new()
+	var colliders := shape._collidable_contours([figure_of_eight] as Array[PackedVector2Array])
+	check("the colliders get resolved geometry", not colliders.is_empty(),
+			"%d colliders" % colliders.size())
+	for collider in colliders:
+		check("collider of %d pts decomposes" % collider.size(),
+				not Geometry2D.decompose_polygon_in_convex(collider).is_empty())
+	shape.free()

--- a/addons/curved_lines_2d/tests/test_collision_contours.gd.uid
+++ b/addons/curved_lines_2d/tests/test_collision_contours.gd.uid
@@ -1,0 +1,1 @@
+uid://d0feux3abhjux


### PR DESCRIPTION
## What the errors actually are

Two different failures, from two different call sites, and they do not always travel
together — which is what kept this confusing:

**`Convex decomposing failed!`** — `decompose_polygon_in_convex()`, called when a
`CollisionPolygon2D` builds its shapes. Fires on load and on every recompute.

**`Invalid polygon data, triangulation failed.`** — `canvas_item_add_polygon()`, from
the editor's collision debug fill. The editor draws every `CollisionPolygon2D` by
decomposing it and filling each piece, so this one fires **once per redraw**, forever,
for as long as the node exists. It is editor-only, which is why it never shows up in a
headless test.

The nastiest case is the last row of the table above: a contour whose decomposition
**succeeds** while emitting a piece the fill then cannot triangulate. That is an
`Invalid polygon data` with no failing decomposition anywhere in sight.

## The six causes

1. **Repeated vertices.** `Geometry2D` hands back contours where the same point occurs
   twice in a row — corners where two clipped edges meet. `_update_assigned_nodes()`
   already dropped the closing vertex when it coincided with the first; the ones in the
   middle got through.
2. **Self-crossing contours.** A shape dragged through itself, or a clip path folded
   over its outline. Resolved by merging the contour with itself, which is done on the
   way *into* the boolean pipeline and again on the way out — the pipeline produces them
   as well as consumes them.
3. **Pinched contours.** Two lobes meeting at one shared vertex. Weakly simple:
   `merge_polygons()` hands them straight back unchanged. They have to be split into the
   loops meeting at that vertex.
4. **Stale contours on surplus nodes.** A node demoted to hidden + disabled kept the
   contour it was last given, and the engine still decomposes it on every rebuild. This
   is your observation from #396, and it is the one **this PR** fixes by removing the
   nodes — with the caveat that the contour also has to be cleared when a node is
   demoted, or a scene that is never saved keeps logging.
5. **Collinear vertices.** `slice_polygon_vertical()` leaves vertices along both halves
   of the cut and re-merging keeps them. Harmless to the shape; the convex partition
   emits a zero-area piece at one of them, which the editor then fails to draw. This is
   where the sub-pixel slivers from #396 actually surface.
6. **Ear clipping is more forgiving than the convex partitioner.** A contour with
   crossings can triangulate happily and still be rejected by the partitioner that
   builds the collision shapes. I captured 18 of these in one editor session, with 16 to
   24 self-intersections each. So `triangulate_polygon()` cannot be used to predict what
   the partitioner will accept — it needs its own test.

## The fix

All six are addressed, in one pipeline. Six helpers on `Geometry2DUtil` —
`remove_duplicate_points`, `normalize_contour`, `split_at_pinch_points`,
`remove_collinear_points`, `is_strictly_simple`, `largest_contour` — and one gate on
`ScalableVectorShape2D`, `_collidable_contours()`, which every contour passes before it
is given a node:

```
sweep repeats -> resolve crossings -> split pinches -> drop collinear
              -> must enclose surface -> must triangulate
              -> must be strictly simple -> must decompose into drawable pieces
```

The last two steps are the editor's own criteria, applied silently in advance. A contour
that cannot pass them is dropped rather than handed on, so the partitioner is never put
in a position where it would print. One silent retry through Clipper is attempted first,
so real surface is not thrown away lightly.

`Polygon2D` and the extra `Line2D` strokes get the same treatment where they are
assigned, since the fill hits the same triangulator.

+455 / −19, plus `test_collision_contours.gd` — 28 checks over six cases, including the
real 17-point contour from a saved scene as a fixture.

## One unrelated thing in the diff

While tracking the above I found the same failure mode in the editor overlay, so the
diff touches `curved_lines_2d.gd` too. `Control.draw_polygon()` triangulates what it is
given and reports the exact same `Invalid polygon data, triangulation failed.` from
`canvas_item_add_polygon()` when it cannot — I confirmed that on a bare `Control`, off
to one side, so it is not inferred.

You already guard the pencil preview against this:

```gdscript
if _is_add_fill_enabled() and Geometry2D.triangulate_polygon(_pencil_stroke).size() > 0:
```

The brush preview is the same kind of input — `_current_brush_stroke` accumulates by
merging as the mouse drags, so it can cross itself just like a freehand pencil loop —
and it was not guarded, nor was the shape preview. I extended your check to those, via a
`_can_be_filled()` helper. The outline keeps being drawn by `draw_polyline()`, which
needs no triangulation; only the fill preview is skipped, and only on the frames where
it could not have been drawn anyway.

This is a latent issue rather than one I saw fire, so it is easy to split out if you
would rather keep this PR to the collider contours.

## Two notes on the pruning in this PR

**`remove_child()` never frees.** The nodes leave the tree so they stay out of the saved
scene, but nothing releases them. On my scene the pre-save prune detaches 37 nodes and
frees none — still allocated and unreachable when the save finishes, and again on every
save. `remove_child(ch)` followed by `ch.queue_free()` covers both; `queue_free()` alone
would not, since the free is deferred past the point where the scene is written.

**The filters reach past the plugin's own nodes.** `ch is Line2D and not ch.visible`
takes out *any* invisible `Line2D` a user parented to the assigned one, and the collider
filter does the same to a `CollisionPolygon2D` someone deliberately disabled and hid.
`_make_new_collision_polygon_2d()` and `_make_new_line_2d()` are the only places these
are created, so a `set_meta()` there and a check for it in the prune would keep it to
nodes the plugin actually owns.

## Verification

With all six covered, both errors are gone. Real editor, cold load, warm load, and
dragging edges across the shape by hand: no errors of either kind. Headless sweep over
four scenes — every curve point moved by eleven offsets, 1408 recomputes — checking
every `CollisionPolygon2D` for decomposition and every `Polygon2D` sub-polygon for
triangulation:

| scene | recomputes | failures |
| --- | --- | --- |
| single shape with one cutout | 88 | 0 |
| nine shapes, all extrusion × collision combinations | 891 | 0 |
| two shapes with two clip paths | 187 | 0 |
| same, rotated | 242 | 0 |

No legitimate collider is lost on the way: the scene with nine shapes keeps 9 to 10
active colliders throughout, never fewer.

| suite | 4.4.stable | 4.7.1.stable |
| --- | --- | --- |
| `test_collision_contours.gd` (new) | FAILURES: 0 | FAILURES: 0 |
| `test_calculate_outlines.gd` | FAILURES: 0 | FAILURES: 0 |
| `test_union_polygons.gd` | FAILURES: 0 | FAILURES: 0 |
| `test_collision_mode.gd` | FAILURES: 0 | FAILURES: 0 |

One behaviour change worth flagging: a shape dragged through itself now fills its lobes
as a union for the duration of the drag, instead of failing to triangulate and dropping
the fill entirely. I think that is the better behaviour, but it is a change, not a fix.
