### PR TITLE
Made `SVGImporter` have only static functions

### DIFF
--- a/addons/curved_lines_2d/examples/import_svg_at_runtime/import_svg_at_runtime.gd
+++ b/addons/curved_lines_2d/examples/import_svg_at_runtime/import_svg_at_runtime.gd
@@ -2,13 +2,21 @@ extends Node2D
 
 
 func _ready():
-	var node := await SVGImporter.new(
-		true, true, false, true, ScalableVectorShape2D.CollisionObjectType.NONE,
-		true, true, 4.0, 5, false,
-		SVGImporter.get_runtime_handler(), print
-	).load_svg("res://addons/curved_lines_2d/tests/01-godot-icon.svg", self, [])
-	var eye_white : ScalableVectorShape2D = find_child("Group").find_child("Circle2")
-	var pupil : ScalableVectorShape2D = find_child("Group2").find_child("Circle")
+	var imported_svg := SVGImporter.load_svg("res://addons/curved_lines_2d/tests/01-godot-icon.svg",{
+		"import_as_svs": true,
+		"lock_shapes": true,
+		"antialiased_shapes": false,
+		"import_stroke_as_line_2d": true,
+		"collision_object_type": ScalableVectorShape2D.CollisionObjectType.NONE,
+		"update_curve_at_runtime": true,
+		"resource_local_to_scene": true,
+		"tolerance_degrees": 4.0,
+		"max_stages": 5,
+		"use_antialiased_line_2d": false
+	},func(msg, log_level): if log_level > SVGImporter.LogLevel.INFO: print(msg))
+	add_child(imported_svg)
+	var eye_white : ScalableVectorShape2D = imported_svg.get_node("Group").get_node("Circle2")
+	var pupil : ScalableVectorShape2D = imported_svg.get_node("Group2").get_node("Circle")
 	eye_white.use_interect_when_clipping = true
 	pupil.clip_paths = [eye_white]
 	get_tree().create_tween().tween_property(eye_white, "size:y", 10.0, 1.0)

--- a/addons/curved_lines_2d/svg_import_tab.gd
+++ b/addons/curved_lines_2d/svg_import_tab.gd
@@ -65,24 +65,43 @@ func _drop_data(at_position: Vector2, data: Variant) -> void:
 
 
 func _load_svg(svg_file_path : String) -> void:
-	var svg_importer := SVGImporter.new(
-		import_as_svs, lock_shapes, antialiased_shapes, import_stroke_as_line_2d,
-		collision_object_type,
-		CurvedLines2D._is_setting_update_curve_at_runtime(),
-		CurvedLines2D._is_making_curve_resources_local_to_scene(),
-		CurvedLines2D._get_default_tolerance_degrees(),
-		CurvedLines2D._get_default_max_stages(),
-		CurvedLines2D._use_antialiased_line_2d(),
-		EditorInterface.get_editor_undo_redo(),
-	 	log_message
-	)
+	if EditorInterface.get_edited_scene_root() is not Node:
+		log_message("ERROR: Can only import into an opened scene", SVGImporter.LogLevel.ERROR)
+		return
+	
+	var loaded_svg := SVGImporter.load_svg(svg_file_path,
+	{
+		"import_as_svs": import_as_svs,
+		"lock_shapes": lock_shapes,
+		"antialiased_shapes":antialiased_shapes,
+		"import_stroke_as_line_2d":import_stroke_as_line_2d,
+		"collision_object_type":collision_object_type,
+		"update_curve_at_runtime": CurvedLines2D._is_setting_update_curve_at_runtime(),
+		"resource_local_to_scene": CurvedLines2D._is_making_curve_resources_local_to_scene(),
+		"tolerance_degrees": CurvedLines2D._get_default_tolerance_degrees(),
+		"max_stages": CurvedLines2D._get_default_max_stages(),
+		"use_antialiased_line_2d": CurvedLines2D._use_antialiased_line_2d()
+	},log_message)
+	if loaded_svg is not Node2D:
+		return
+	
+	var svg_parent = EditorInterface.get_edited_scene_root() if \
+		EditorInterface.get_selection().get_selected_nodes().size() != 1 else \
+		EditorInterface.get_selection().get_selected_nodes()[0]
+	var svg_owner = EditorInterface.get_edited_scene_root()
+	
+	undo_redo.create_action("Import SVG file as Nodes: %s" % loaded_svg.name)
+	if !import_as_svs:
+		await RenderingServer.frame_post_draw
+		loaded_svg = SVSSceneExporter.copy_baked_node(loaded_svg, svg_parent, svg_owner)
+	svg_parent.add_child(loaded_svg)
+	_recursive_set_owner(svg_parent, svg_owner, svg_owner)
+	undo_redo.add_do_method(svg_parent, "add_child", loaded_svg, true)
+	undo_redo.add_undo_method(svg_parent, "remove_child", loaded_svg)
+	undo_redo.commit_action(false)
+
 	for child in %ImportLogContainer.get_children():
 		child.queue_free()
-	var svg_root := await svg_importer.load_svg(svg_file_path,
-		EditorInterface.get_edited_scene_root(),
-		EditorInterface.get_selection().get_selected_nodes()
-	)
-
 	log_message("Import finished.\n\nThe SVG importer is still incrementally improving (slowly).")
 	var link_button = LinkButtonScene.instantiate()
 	link_button.text = "Click here to report issues or improvement requests on github"
@@ -90,11 +109,11 @@ func _load_svg(svg_file_path : String) -> void:
 	%ImportLogContainer.add_child(link_button)
 
 	var selection_target = (
-			svg_root.find_children("*", "ScalableVectorShape2D")
+			loaded_svg.find_children("*", "ScalableVectorShape2D")
 				.filter(func(n : CanvasItem): return n.is_visible_in_tree()).pop_front()
 	)
 	if not is_instance_valid(selection_target):
-		selection_target = svg_root
+		selection_target = loaded_svg
 	EditorInterface.call_deferred('edit_node', selection_target)
 	await get_tree().create_timer(0.0167).timeout
 	EditorInterface.get_editor_viewport_2d().get_parent().grab_focus()
@@ -103,6 +122,12 @@ func _load_svg(svg_file_path : String) -> void:
 	key_ev.pressed = true
 	Input.parse_input_event(key_ev)
 
+func _recursive_set_owner(node : Node, new_owner : Node, root : Node):
+	node.owner = root
+	undo_redo.add_do_property(node, 'owner', new_owner)
+	undo_redo.add_undo_reference(node)
+	for child in node.get_children():
+		_recursive_set_owner(child, new_owner, root)
 
 func _on_collision_object_type_option_button_type_selected(obj_type: ScalableVectorShape2D.CollisionObjectType) -> void:
 	collision_object_type = obj_type

--- a/addons/curved_lines_2d/svg_importer.gd
+++ b/addons/curved_lines_2d/svg_importer.gd
@@ -8,15 +8,6 @@ const PLC_EXP = "__PLC_EXP__"
 const SVG_ROOT_META_NAME := "svg_root"
 const SVG_STYLE_META_NAME := "svg_style"
 
-const PAINT_ORDER_MAP := {
-	"normal": ['add_fill_to_path', 'add_stroke_to_path', 'add_collision_to_path'],
-	"fill stroke markers": ['add_fill_to_path', 'add_stroke_to_path', 'add_collision_to_path'],
-	"stroke fill markers": ['add_stroke_to_path', 'add_fill_to_path', 'add_collision_to_path'],
-	"fill markers stroke": ['add_fill_to_path', 'add_collision_to_path', 'add_stroke_to_path'],
-	"markers fill stroke": ['add_collision_to_path', 'add_fill_to_path', 'add_stroke_to_path'],
-	"stroke markers fill": ['add_stroke_to_path', 'add_collision_to_path', 'add_fill_to_path'],
-	"markers stroke fill": ['add_collision_to_path', 'add_stroke_to_path', 'add_fill_to_path']
-}
 const STROKE_CAP_MAP := {
 	"butt": Line2D.LineCapMode.LINE_CAP_NONE,
 	"round": Line2D.LineCapMode.LINE_CAP_ROUND,
@@ -32,81 +23,25 @@ const STROKE_JOINT_MAP := {
 
 enum LogLevel { DEBUG, INFO, WARN, ERROR }
 
-## Settings
-var import_as_svs := true
-var lock_shapes := true
-var antialiased_shapes := false
-var import_stroke_as_line_2d := true
-var collision_object_type := ScalableVectorShape2D.CollisionObjectType.NONE
-var update_curve_at_runtime := true
-var resource_local_to_scene := true
-var tolerance_degrees := 4.0
-var max_stages : int = 5
-var use_antialiased_line_2d = false
-
-var undo_redo : Variant = null
-var log_consumer : Callable = func(msg: String, log_level : LogLevel): pass
-
-func _init(is_svs := true, is_lock := true, is_aa := false, is_line_2d := true,
-		coll_type := ScalableVectorShape2D.CollisionObjectType.NONE,
-		is_update_curve_at_runtime := true,
-		is_resource_local_to_scene := true,
-		tol_deg := 4.0, max_stg := 5,
-		using_antialiased_line_2d := false,
-		undo_redo_handler : Variant = null,
-		on_log := func(msg: String, log_level : LogLevel): pass) -> void:
-	import_as_svs = is_svs
-	lock_shapes = is_lock
-	antialiased_shapes = is_aa
-	import_stroke_as_line_2d = is_line_2d
-	collision_object_type = coll_type
-	update_curve_at_runtime = is_update_curve_at_runtime
-	resource_local_to_scene = is_resource_local_to_scene
-	tolerance_degrees = tol_deg
-	max_stages = max_stg
-	use_antialiased_line_2d = using_antialiased_line_2d
-	undo_redo = undo_redo_handler
-	log_consumer = on_log
-
-
-func log_message(msg : String, log_level : LogLevel = LogLevel.INFO) -> void:
-	log_consumer.call(msg, log_level)
-
-
-func load_svg(file_path : String, scene_root := Node2D.new(), selected_nodes : Array[Node] = []) -> Node:
+## Import an svg file as [ScaleableVectorShape2D]s.
+static func load_svg(file_path : String, import_settings := {}, logger := func(msg : String, log_level := LogLevel.INFO): print(msg)) -> Node:
 	var xml_parser = XMLParser.new()
-	var parent_node := scene_root if selected_nodes.is_empty() else selected_nodes[0]
-	if not scene_root is Node:
-		log_message("ERROR: Can only import into an opened scene", LogLevel.ERROR)
-		return
 	if xml_parser.open(file_path) != OK:
-		log_message("ERROR: Failed to open %s for reading" % file_path, LogLevel.ERROR)
+		logger.call("ERROR: Failed to open %s for reading" % file_path, LogLevel.ERROR)
 		return
-
-	log_message("Importing SVG file: %s" % file_path, LogLevel.INFO)
-	var svg_root := Node2D.new()
-	svg_root.name = file_path.get_file().replace(".svg", "").to_pascal_case()
-	undo_redo.create_action("Import SVG file as Nodes: %s" % svg_root.name)
-	svg_root.set_meta(SVG_ROOT_META_NAME, true)
-
-	_managed_add_child_and_set_owner(parent_node, svg_root, scene_root)
-
-	var current_node := svg_root
-	var svg_gradients : Array[Dictionary] = []
-
 	var svg_xml_node : SVGXMLElement = parse_svg_xml_file(xml_parser)
-	process_svg_xml_tree(svg_xml_node, scene_root, svg_root, current_node, svg_gradients)
-	undo_redo.commit_action(false)
+	
+	logger.call("Importing SVG file: %s" % file_path, LogLevel.INFO)
+	var svg_output := process_svg_xml_tree(svg_xml_node, [], import_settings, logger)
+	if svg_output.size() != 1:
+		logger.call("ERROR: SVG file %s parse incorrectly - more than one root node" % file_path, LogLevel.DEBUG)
+		return
+	svg_output[0].name = file_path.get_file().replace(".svg", "").to_pascal_case()
+	svg_output[0].set_meta(SVG_ROOT_META_NAME, true)
+	return svg_output[0]
 
-	if not import_as_svs:
-		await RenderingServer.frame_post_draw
-		SVSSceneExporter.copy_baked_node(svg_root, parent_node, scene_root)
-		parent_node.remove_child(svg_root)
-		return parent_node
-	return svg_root
-
-
-func parse_svg_xml_file(xml_parser : XMLParser) -> SVGXMLElement:
+## Convert raw svg file into tree structure
+static func parse_svg_xml_file(xml_parser : XMLParser) -> SVGXMLElement:
 	var svg_xml_node : SVGXMLElement = null
 	while xml_parser.read() == OK:
 		if not xml_parser.get_node_type() in [XMLParser.NODE_ELEMENT, XMLParser.NODE_ELEMENT_END]:
@@ -117,88 +52,71 @@ func parse_svg_xml_file(xml_parser : XMLParser) -> SVGXMLElement:
 			if svg_xml_node.parent:
 				svg_xml_node = svg_xml_node.parent
 		else:
-			var new_svg_xml_node := SVGXMLElement.new(xml_parser, svg_xml_node)
+			var name = xml_parser.get_node_name()
+			var attributes : Dictionary[String, String]= {}
+			for i in xml_parser.get_attribute_count():
+				attributes[xml_parser.get_attribute_name(i)] = xml_parser.get_attribute_value(i)
+			var new_svg_xml_node := SVGXMLElement.new(name, attributes, svg_xml_node)
 			if svg_xml_node:
 				svg_xml_node.add_child(new_svg_xml_node)
 			if not xml_parser.is_empty():
 				svg_xml_node = new_svg_xml_node
 	return svg_xml_node
 
-func process_svg_xml_tree(xml_data : SVGXMLElement, scene_root : Node, svg_root :
-			Node2D, current_node : Node2D, svg_gradients : Array[Dictionary]) -> void:
-
-	if xml_data.name == "use":
-		var href = xml_data.get_named_attribute_value_safe("xlink:href")
-		if href.is_empty():
-			href = xml_data.get_named_attribute_value_safe("href")
-		var reuse_xml_node = xml_data.find_by_id(href.replace("#", ""))
-		var style = xml_data.get_svg_style(log_message)
-		style.merge(reuse_xml_node.get_merged_styles(log_message))
-		var preserve_id := xml_data.get_named_attribute_value_safe("id")
-		xml_data.attributes.erase("xlink:href")
-		xml_data.attributes.merge(reuse_xml_node.attributes)
-		xml_data.attributes["id"] = preserve_id
-		xml_data.attributes["style"] = "; ".join(style.keys().map(func(k): return k + ": " + style[k]))
-		if preserve_id.is_empty():
-			xml_data.attributes.erase("id")
-		xml_data.name = reuse_xml_node.name
-
+## Recursively turn an [SVGXMLElement] tree into [ScaleableVectorShape2D]s.
+static func process_svg_xml_tree(xml_data : SVGXMLElement, svg_gradients : Array[Dictionary], import_settings: Dictionary, logger : Callable, defs : Node = null) -> Array:
+	if xml_data.name == "use": derefrence_use_tag(xml_data, logger)
+	
 	match xml_data.name:
 		"svg":
-			if xml_data.has_attribute("viewBox") and xml_data.has_attribute("width") and xml_data.has_attribute("height"):
-				var view_box = xml_data.get_named_attribute_value("viewBox").split_floats(" ")
-				var width := float(xml_data.get_named_attribute_value("width"))
-				var height := float(xml_data.get_named_attribute_value("height"))
-				svg_root.scale.x = width / view_box[2]
-				svg_root.scale.y = height / view_box[3]
-				if xml_data.get_named_attribute_value("width").ends_with("mm"): # unit conversion to pixel
-					log_message("⚠️ Units for this image are millimeters (mm), image scale set to 3.78")
-					svg_root.scale *= 3.78
-				elif xml_data.get_named_attribute_value("width").ends_with("cm"):
-					log_message("⚠️ Units for this image are centimeters (cm), image scale set to 37.8")
-					svg_root.scale *= 37.8
-			if xml_data.has_attribute("style"):
-				current_node.set_meta(SVG_STYLE_META_NAME, xml_data.get_merged_styles(log_message))
-		"g":
-			current_node = process_group(xml_data, current_node, scene_root)
-		"clipPath", "defs":
-			current_node = process_group(xml_data, current_node, scene_root, xml_data.name)
-			current_node.hide()
+			return [process_svg(xml_data, svg_gradients, import_settings, logger)]
+		"g", "clipPath", "defs":
+			return [process_group(xml_data, svg_gradients, import_settings, defs, logger)]
 		"rect":
-			process_svg_rectangle(xml_data, current_node, scene_root, svg_gradients)
+			return process_svg_rectangle(xml_data, svg_gradients, import_settings, defs, logger)
 		"image":
-			process_svg_image(xml_data, current_node, scene_root, svg_gradients)
+			return process_svg_image(xml_data, svg_gradients, import_settings, defs, logger)
 		"polygon":
-			process_svg_polygon(xml_data, current_node, scene_root, true, svg_gradients)
+			return process_svg_polygon(xml_data, true, svg_gradients, import_settings, defs, logger)
 		"polyline":
-			process_svg_polygon(xml_data, current_node, scene_root, false, svg_gradients)
+			return process_svg_polygon(xml_data, false, svg_gradients, import_settings, defs, logger)
 		"path":
-			process_svg_path(xml_data, current_node, scene_root, svg_gradients)
+			return process_svg_path(xml_data, svg_gradients, import_settings, defs, logger)
 		"circle":
-			process_svg_circle(xml_data, current_node, scene_root, svg_gradients)
+			return process_svg_circle(xml_data, svg_gradients, import_settings, defs, logger)
 		"ellipse":
-			process_svg_ellipse(xml_data, current_node, scene_root, svg_gradients)
+			return process_svg_ellipse(xml_data, svg_gradients, import_settings, defs, logger)
 		"linearGradient", "radialGradient":
-			svg_gradients.append(parse_gradient(xml_data))
+			svg_gradients.append(parse_gradient(xml_data, logger))
 		"stop":
 			pass
-		_: log_message("⚠️ Skipping  unsupported node: <%s>" % xml_data.name, LogLevel.DEBUG)
+		_: logger.call("⚠️ Skipping  unsupported node: <%s>" % xml_data.name, LogLevel.DEBUG)
+	return []
 
-	var defs := xml_data.children.filter(func(ch): return ch.name == "defs")
-	var clip_paths := xml_data.children.filter(func(ch): return ch.name == "clipPath")
-	var remainder := xml_data.children.filter(func(ch): return ch.name != "defs" and ch.name != "clipPath")
-	for ch in defs + clip_paths + remainder:
-		process_svg_xml_tree(ch, scene_root, svg_root, current_node, svg_gradients)
+## Convert "use" xml tag to something actually importable
+static func derefrence_use_tag(xml_data: SVGXMLElement, logger : Callable):
+	var href = xml_data.get_named_attribute_value_safe("xlink:href")
+	if href.is_empty():
+		href = xml_data.get_named_attribute_value_safe("href")
+	var reuse_xml_node = xml_data.find_by_id(href.replace("#", ""))
+	var style = xml_data.get_svg_style(logger)
+	style.merge(reuse_xml_node.get_merged_styles(logger))
+	var preserve_id := xml_data.get_named_attribute_value_safe("id")
+	xml_data.attributes.erase("xlink:href")
+	xml_data.attributes.merge(reuse_xml_node.attributes)
+	xml_data.attributes["id"] = preserve_id
+	xml_data.attributes["style"] = "; ".join(style.keys().map(func(k): return k + ": " + style[k]))
+	if preserve_id.is_empty():
+		xml_data.attributes.erase("id")
+	xml_data.name = reuse_xml_node.name
 
-
-func get_gradient_by_href(href : String, gradients : Array[Dictionary]) -> Dictionary:
+static func get_gradient_by_href(href : String, gradients : Array[Dictionary]) -> Dictionary:
 	var idx := gradients.find_custom(func(x): return "id" in x and "#" + x["id"] == href)
 	if idx < 0:
 		return {}
 	return gradients[idx]
 
-
-func parse_gradient(gradient_xml : SVGXMLElement) -> Dictionary:
+static func parse_gradient(gradient_xml : SVGXMLElement, logger : Callable) -> Dictionary:
 	var new_gradient = {
 		'is_radial': gradient_xml.get_node_name() == "radialGradient"
 	}
@@ -209,67 +127,92 @@ func parse_gradient(gradient_xml : SVGXMLElement) -> Dictionary:
 		for element in gradient_xml.children:
 			if element.get_node_name() == "stop":
 				new_gradient["stops"].append({
-					"style": element.get_merged_styles(log_message),
+					"style": element.get_merged_styles(logger),
 					"offset": float(element.get_named_attribute_value_safe("offset")),
 					"id": element.get_named_attribute_value_safe("id")
 				})
 
 	return new_gradient
 
-
-func get_element_label(element: SVGXMLElement, alt_name : String) -> String:
+static func get_element_label(element: SVGXMLElement, alt_name : String) -> String:
 	if element.has_attribute("inkscape:label"):
 		return element.get_named_attribute_value("inkscape:label")
 	elif element.has_attribute("id"):
 		return element.get_named_attribute_value("id")
 	return alt_name
 
+static func process_svg(xml_data: SVGXMLElement, svg_gradients : Array[Dictionary], import_settings : Dictionary, logger : Callable) -> Node2D:
+	var top_level_svg_node := Node2D.new()
+	if xml_data.has_attribute("viewBox") and xml_data.has_attribute("width") and xml_data.has_attribute("height"):
+		var view_box = xml_data.get_named_attribute_value("viewBox").split_floats(" ")
+		var width := float(xml_data.get_named_attribute_value("width"))
+		var height := float(xml_data.get_named_attribute_value("height"))
+		top_level_svg_node.scale.x = width / view_box[2]
+		top_level_svg_node.scale.y = height / view_box[3]
+		if xml_data.get_named_attribute_value("width").ends_with("mm"): # unit conversion to pixel
+			logger.call("⚠️ Units for this image are millimeters (mm), image scale set to 3.78", LogLevel.INFO)
+			top_level_svg_node.scale *= 3.78
+		elif xml_data.get_named_attribute_value("width").ends_with("cm"):
+			logger.call("⚠️ Units for this image are centimeters (cm), image scale set to 37.8", LogLevel.INFO)
+			top_level_svg_node.scale *= 37.8
+	if xml_data.has_attribute("style"):
+		top_level_svg_node.set_meta(SVG_STYLE_META_NAME, xml_data.get_merged_styles(logger))
+	var defs : Node = null
+	for child in xml_data.children:
+		var child_output := process_svg_xml_tree(child,svg_gradients, import_settings, logger, defs)
+		for grandchild in child_output:
+			if child.name == "defs": defs = grandchild
+			elif child_output: top_level_svg_node.add_child(grandchild,true)
+	return top_level_svg_node
 
-func process_group(element:SVGXMLElement, current_node : Node2D, scene_root : Node, alt_name := "Group") -> Node2D:
+static func process_group(xml_data:SVGXMLElement, svg_gradients : Array[Dictionary], import_settings : Dictionary, defs : Node, logger : Callable) -> Node2D:
 	var new_group = Node2D.new()
-	new_group.name = get_element_label(element, alt_name)
-	new_group.transform = get_svg_transform(element)
-	var style := element.get_merged_styles(log_message)
+	new_group.name = get_element_label(xml_data, xml_data.name if xml_data.name != "g" else "Group")
+	new_group.transform = get_svg_transform(xml_data)
+	var style := xml_data.get_merged_styles(logger)
 	new_group.set_meta(SVG_STYLE_META_NAME, style)
 
 	if style.has("display") and style['display'] == "none":
 		new_group.visible = false
-	_managed_add_child_and_set_owner(current_node, new_group, scene_root)
+	for child in xml_data.children:
+		var child_output := process_svg_xml_tree(child, svg_gradients, import_settings, logger, defs)
+		for grandchild in child_output:
+			new_group.add_child(grandchild,true)
+	new_group.visible = xml_data.name == "g"
 	return new_group
 
-
-func process_svg_circle(element:SVGXMLElement, current_node : Node2D, scene_root : Node,
-		gradients : Array[Dictionary]) -> void:
+static func process_svg_circle(element:SVGXMLElement,
+		gradients : Array[Dictionary], import_settings : Dictionary, defs : Node, logger : Callable = func(mesg : String): pass) -> Array[ScalableVectorShape2D]:
 	var cx = float(element.get_named_attribute_value("cx"))
 	var cy = float(element.get_named_attribute_value("cy"))
 	var r = float(element.get_named_attribute_value("r"))
 	var path_name = get_element_label(element, "Circle")
-	create_path_from_ellipse(element, path_name, r, r, Vector2(cx, cy), current_node, scene_root, gradients)
+	return create_path_from_ellipse(element, path_name, r, r, Vector2(cx, cy), gradients, import_settings, defs, logger)
 
 
-func process_svg_ellipse(element:SVGXMLElement, current_node : Node2D, scene_root : Node,
-		gradients : Array[Dictionary]) -> void:
+static func process_svg_ellipse(element:SVGXMLElement, 
+		gradients : Array[Dictionary], import_settings : Dictionary, defs : Node, logger : Callable = func(mesg : String): pass) -> Array[ScalableVectorShape2D]:
 	var cx = float(element.get_named_attribute_value("cx"))
 	var cy = float(element.get_named_attribute_value("cy"))
 	var rx = float(element.get_named_attribute_value("rx"))
 	var ry = float(element.get_named_attribute_value("ry"))
 	var path_name = get_element_label(element, "Ellipse")
-	create_path_from_ellipse(element, path_name, rx, ry, Vector2(cx, cy), current_node, scene_root, gradients)
+	return create_path_from_ellipse(element, path_name, rx, ry, Vector2(cx, cy), gradients, import_settings, defs, logger)
 
 
-func create_path_from_ellipse(element:SVGXMLElement, path_name : String, rx : float, ry: float,
-		pos : Vector2, current_node : Node2D, scene_root : Node,
-		gradients : Array[Dictionary]) -> void:
+static func create_path_from_ellipse(element:SVGXMLElement, path_name : String, rx : float, ry: float,
+		pos : Vector2, 
+		gradients : Array[Dictionary], import_settings : Dictionary, defs : Node, logger : Callable) -> Array[ScalableVectorShape2D]:
 	var new_ellipse := ScalableVectorShape2D.new()
 	new_ellipse.shape_type = ScalableVectorShape2D.ShapeType.ELLIPSE
 	new_ellipse.size = Vector2(rx * 2, ry * 2)
 	new_ellipse.position = pos
 	new_ellipse.name = path_name
-	_post_process_shape(new_ellipse, current_node, get_svg_transform(element),
-			element.get_merged_styles(log_message), scene_root, gradients)
+	return _post_process_shape(new_ellipse, import_settings, defs, get_svg_transform(element),
+			element.get_merged_styles(logger), gradients)
 
-func process_svg_image(element:SVGXMLElement, current_node : Node2D, scene_root : Node,
-		gradients : Array[Dictionary]) -> void:
+static func process_svg_image(element:SVGXMLElement,
+		gradients : Array[Dictionary], import_settings : Dictionary, defs : Node, logger : Callable) -> Array[ScalableVectorShape2D]:
 	var x = float(element.get_named_attribute_value("x")) if element.has_attribute("x") else 0.0
 	var y = float(element.get_named_attribute_value("y")) if element.has_attribute("y") else 0.0
 	var width = float(element.get_named_attribute_value("width"))
@@ -294,16 +237,15 @@ func process_svg_image(element:SVGXMLElement, current_node : Node2D, scene_root 
 		var image := Image.new()
 		image.call("load_%s_from_buffer" % format.to_lower(), unmarshalled)
 		image_texture = ImageTexture.create_from_image(image)
-		log_message("Parsed image format: %s" % format, LogLevel.DEBUG)
+		logger.call("Parsed image format: %s" % format, LogLevel.DEBUG)
 	else:
-		log_message("⚠️ Only base64 encoded embedded images are supported", LogLevel.WARN)
+		logger.call("⚠️ Only base64 encoded embedded images are supported", LogLevel.WARN)
 
-	_post_process_shape(new_image_rect, current_node, get_svg_transform(element),
-			element.get_merged_styles(log_message), scene_root, gradients, false, image_texture)
+	return _post_process_shape(new_image_rect, import_settings, defs, get_svg_transform(element),
+			element.get_merged_styles(logger), gradients, false, image_texture)
 
-
-func process_svg_rectangle(element:SVGXMLElement, current_node : Node2D, scene_root : Node,
-		gradients : Array[Dictionary]) -> void:
+static func process_svg_rectangle(element:SVGXMLElement,
+		gradients : Array[Dictionary], import_settings : Dictionary, defs : Node, logger : Callable) -> Array[ScalableVectorShape2D]:
 	var x = float(element.get_named_attribute_value("x"))
 	var y = float(element.get_named_attribute_value("y"))
 	var rx = float(element.get_named_attribute_value("rx")) if element.has_attribute("rx") else 0
@@ -321,12 +263,12 @@ func process_svg_rectangle(element:SVGXMLElement, current_node : Node2D, scene_r
 	new_rect.rx = rx
 	new_rect.ry = ry
 	new_rect.name = get_element_label(element, "Rectangle")
-	_post_process_shape(new_rect, current_node, get_svg_transform(element),
-			element.get_merged_styles(log_message), scene_root, gradients)
+	return _post_process_shape(new_rect, import_settings, defs, get_svg_transform(element),
+			element.get_merged_styles(logger), gradients)
 
 
-func process_svg_polygon(element:SVGXMLElement, current_node : Node2D, scene_root : Node, is_closed : bool,
-		gradients : Array[Dictionary]) -> void:
+static func process_svg_polygon(element:SVGXMLElement, is_closed : bool,
+		gradients : Array[Dictionary], import_settings : Dictionary, defs : Node, logger : Callable) -> Array[ScalableVectorShape2D]:
 	var points_split = (element.get_named_attribute_value("points")
 			.replacen(",", " ")
 			.split(" ", false)
@@ -335,12 +277,14 @@ func process_svg_polygon(element:SVGXMLElement, current_node : Node2D, scene_roo
 	for p_idx in range(0, points_split.size(), 2):
 		curve.add_point(Vector2(float(points_split[p_idx]), float(points_split[p_idx + 1])))
 	var path_name = get_element_label(element, "Polygon" if is_closed else "Polyline")
-	create_path2d(path_name, current_node, curve, [], get_svg_transform(element),
-			element.get_merged_styles(log_message), scene_root, gradients, is_closed)
+
+	return create_path2d(path_name, curve, [], import_settings, defs, get_svg_transform(element),
+			element.get_merged_styles(logger), gradients, is_closed)
 
 
-func process_svg_path(element:SVGXMLElement, current_node : Node2D, scene_root : Node,
-		gradients : Array[Dictionary]) -> void:
+
+static func process_svg_path(element:SVGXMLElement,
+		gradients : Array[Dictionary], import_settings : Dictionary, defs : Node, logger : Callable) -> Array[ScalableVectorShape2D]:
 
 	# FIXME: implement better parsing here
 	var str_path = parse_attribute_string(
@@ -366,7 +310,7 @@ func process_svg_path(element:SVGXMLElement, current_node : Node2D, scene_root :
 	string_arrays.append(string_array_top)
 
 	if string_arrays.size() > 1:
-		log_message("⚠️ Support for the m/M (move to) command is limited to cut-outs in svg paths")
+		logger.call("⚠️ Support for the m/M (move to) command is limited to cut-outs in svg paths", LogLevel.WARN)
 	var string_array_count = 0
 	var cursor = Vector2.ZERO
 	var shapes : Array[ScalableVectorShape2D] = []
@@ -536,7 +480,7 @@ func process_svg_path(element:SVGXMLElement, current_node : Node2D, scene_root :
 		shape.set_meta("is_closed", string_array[string_array.size()-1].to_upper() == "Z")
 		shapes.append(shape)
 
-	log_message("Postprocessing for %s" % shape_name, LogLevel.DEBUG)
+	logger.call("Postprocessing for %s" % shape_name, LogLevel.DEBUG)
 	# Loop through al the shapes in this <path> element looking for holes
 	# if a shape is a hole, make sure it is not in the post_processed_shapes
 	# array after this loop, but a member of the surrounding shape's clip_paths
@@ -560,29 +504,32 @@ func process_svg_path(element:SVGXMLElement, current_node : Node2D, scene_root :
 						shape.clip_paths.append(shape1)
 					post_processed_shapes.erase(shape1)
 
+	var path_shapes : Array[ScalableVectorShape2D] = []
 	# Append actual new shapes to the scene by copying the `curve`, `arc_list` and
 	# `clip_paths`. Also, the shapes inside the `clip_paths` property are added as
 	# actual node in the resulting scene
 	for shape in post_processed_shapes:
-		var new_path := create_path2d(shape_name, current_node,  shape.curve.duplicate(true), shape.arc_list.arcs.duplicate(true), get_svg_transform(element),
-					element.get_merged_styles(log_message), scene_root, gradients, shape.get_meta("is_closed"))
+		var new_path := create_path2d(shape_name, shape.curve.duplicate(true), 
+					shape.arc_list.arcs.duplicate(true), import_settings, defs, get_svg_transform(element),
+					element.get_merged_styles(logger), gradients, shape.get_meta("is_closed"))
+		path_shapes.append_array(new_path)
 		var clips : Array[ScalableVectorShape2D] = []
 		for cutout in shape.clip_paths:
-			clips.append(create_path2d("CutoutFor%s" % shape_name, current_node, cutout.curve.duplicate(true), cutout.arc_list.arcs.duplicate(true),
-							Transform2D.IDENTITY, {}, scene_root, gradients, cutout.get_meta("is_closed"), new_path))
+			var new_clip_path := create_path2d("CutoutFor%s" % shape_name, cutout.curve.duplicate(true), cutout.arc_list.arcs.duplicate(true), 
+						import_settings, defs, Transform2D.IDENTITY, {},  gradients, cutout.get_meta("is_closed"), new_path[-1])
+			clips.append_array(new_clip_path)
 			cutout.free()
 		shape.free()
 		# append_array is used here, because clip paths may already have been added via the
 		# `create_path2d(...)` call chain.
-		new_path.clip_paths.append_array(clips)
-		undo_redo.add_do_property(new_path, 'clip_paths', new_path.clip_paths)
-		undo_redo.add_undo_property(new_path, 'clip_paths', [])
+		new_path[-1].clip_paths.append_array(clips)
+	return path_shapes
 
 
-func create_path2d(path_name: String, parent: Node, curve: Curve2D, arcs: Array[ScalableArc],
-						transform: Transform2D, style: Dictionary, scene_root: Node,
-						gradients : Array[Dictionary], is_closed := false,
-						is_cutout_for : ScalableVectorShape2D = null) -> ScalableVectorShape2D:
+static func create_path2d(path_name: String,  curve: Curve2D, arcs: Array[ScalableArc], 
+						import_settings : Dictionary, defs : Node, transform: Transform2D, 
+						style: Dictionary, gradients : Array[Dictionary], is_closed := false,
+						is_cutout_for : ScalableVectorShape2D = null) -> Array[ScalableVectorShape2D]:
 	var new_path = ScalableVectorShape2D.new()
 	new_path.name = path_name
 	new_path.curve = curve
@@ -594,50 +541,27 @@ func create_path2d(path_name: String, parent: Node, curve: Curve2D, arcs: Array[
 	if is_cutout_for:
 		new_path.transform = is_cutout_for.transform.affine_inverse()
 		new_path.set_position_to_center()
-		_post_process_shape(new_path, is_cutout_for, transform, style, scene_root, gradients, true)
+		return _post_process_shape(new_path, import_settings, defs, transform, style, gradients, true)
 	else:
 		new_path.set_position_to_center()
-		_post_process_shape(new_path, parent, transform, style, scene_root, gradients, false)
-	return new_path
+		return _post_process_shape(new_path, import_settings, defs, transform, style, gradients, false)
 
 
-func _apply_clip_path_by_href(href : String, svs : ScalableVectorShape2D, scene_root : Node):
-	var clip_path_node := scene_root.find_child(href.replace("url(#", "").replace(")", ""))
-	var new_clip_paths : Array[ScalableVectorShape2D] = []
-	for clip_path : ScalableVectorShape2D in clip_path_node.find_children("*", "ScalableVectorShape2D"):
-		clip_path.use_interect_when_clipping = true
-		if clip_path.line:
-			clip_path.line.hide()
-		if clip_path.polygon:
-			clip_path.polygon.hide()
-		var applied_clip_path = clip_path.duplicate()
-		new_clip_paths.append(applied_clip_path)
-		_managed_add_child_and_set_owner(svs.get_parent(), applied_clip_path, scene_root)
-
-	log_message("Processing %d clip-paths for %s" % [new_clip_paths.size(), svs.name], LogLevel.DEBUG)
-	svs.clip_paths = new_clip_paths
-	undo_redo.add_do_property(svs, 'clip_paths', new_clip_paths)
-	undo_redo.add_undo_property(svs, 'clip_paths', [])
-
-
-func _post_process_shape(svs : ScalableVectorShape2D, parent : Node, transform : Transform2D,
-			style : Dictionary, scene_root : Node, gradients : Array[Dictionary],
-			is_cutout := false, image_texture : ImageTexture = null) -> void:
-	svs.lock_assigned_shapes = import_as_svs and lock_shapes
-	svs.update_curve_at_runtime = update_curve_at_runtime
-	svs.arc_list.resource_local_to_scene = resource_local_to_scene
-	svs.curve.resource_local_to_scene = resource_local_to_scene
-	svs.tolerance_degrees = tolerance_degrees
-	svs.max_stages = max_stages
-	var gradient_point_parent : Node2D = parent
-	if transform == Transform2D.IDENTITY:
-		_managed_add_child_and_set_owner(parent, svs, scene_root)
-	else:
+static func _post_process_shape(svs : ScalableVectorShape2D, import_settings : Dictionary, defs: Node,
+			transform : Transform2D, style : Dictionary, gradients : Array[Dictionary],
+			is_cutout := false, image_texture : ImageTexture = null, logger : Callable = func(msg,lvl): pass) -> Array[ScalableVectorShape2D]:
+	svs.lock_assigned_shapes = import_settings.get("import_as_svs", true) and import_settings.get("lock_shapes", true)
+	svs.update_curve_at_runtime = import_settings.get("update_curve_at_runtime", false)
+	svs.arc_list.resource_local_to_scene = import_settings.get("resource_local_to_scene",true)
+	svs.curve.resource_local_to_scene = import_settings.get("resource_local_to_scene",true)
+	svs.tolerance_degrees = import_settings.get("tolerance_degrees", 4.0)
+	svs.max_stages = import_settings.get("max_stages",5)
+	var gradient_point_parent : Node2D = svs
+	if transform != Transform2D.IDENTITY:
 		var transform_node := Node2D.new()
 		transform_node.name = svs.name + "Transform"
 		transform_node.transform = transform
-		_managed_add_child_and_set_owner(parent, transform_node, scene_root)
-		_managed_add_child_and_set_owner(transform_node, svs, scene_root)
+		transform_node.add_child(svs, true)
 		gradient_point_parent = transform_node
 
 	if style.has("opacity"):
@@ -649,133 +573,178 @@ func _post_process_shape(svs : ScalableVectorShape2D, parent : Node, transform :
 	if style.has("display") and style['display'] == "none":
 		svs.visible = false
 
+
+	var PAINT_ORDER_MAP := {
+		"normal": [add_fill_to_path, add_stroke_to_path, add_collision_to_path],
+		"fill stroke markers": [add_fill_to_path, add_stroke_to_path, add_collision_to_path],
+		"stroke fill markers": [add_stroke_to_path, add_fill_to_path, add_collision_to_path],
+		"fill markers stroke": [add_fill_to_path, add_collision_to_path, add_stroke_to_path],
+		"markers fill stroke": [add_collision_to_path, add_fill_to_path, add_stroke_to_path],
+		"stroke markers fill": [add_stroke_to_path, add_collision_to_path, add_fill_to_path],
+		"markers stroke fill": [add_collision_to_path, add_stroke_to_path, add_fill_to_path]
+	}
 	if not is_cutout:
-		for func_name in PAINT_ORDER_MAP[get_paint_order(style)]:
-			call(func_name, svs, style, scene_root, gradients,
-					gradient_point_parent, image_texture)
+		for paint_func : Callable in PAINT_ORDER_MAP[get_paint_order(style)]:
+			paint_func.call(svs, style, gradients, import_settings,
+					gradient_point_parent, image_texture, logger)
 
 	if "clip-path" in style:
-		_apply_clip_path_by_href(style["clip-path"], svs, scene_root)
+		var svs_clippers = apply_clip_path_by_href(style["clip-path"], defs, svs, logger)
+		svs_clippers.append(gradient_point_parent)
+		return svs_clippers
+	
+	return [gradient_point_parent]
 
 
-func get_paint_order(style : Dictionary) -> String:
-	if style.has("paint-order") and style['paint-order'] in PAINT_ORDER_MAP:
+static func get_paint_order(style : Dictionary) -> String:
+	if style.has("paint-order") and style['paint-order'] in [
+		"normal",
+		"fill stroke markers",
+		"stroke fill markers",
+		"fill markers stroke",
+		"markers fill stroke",
+		"stroke markers fill",
+		"markers stroke fill"
+		]:
 		return style['paint-order']
 	else:
 		return "normal"
 
+static func apply_clip_path_by_href(href : String, defs : Node, svs : ScalableVectorShape2D, logger : Callable) -> Array[ScalableVectorShape2D]:
+	var clip_path_node := defs.find_child(href.replace("url(#", "").replace(")", ""))
+	var new_clip_paths : Array[ScalableVectorShape2D] = []
+	for clip_path : ScalableVectorShape2D in clip_path_node.find_children("*", "ScalableVectorShape2D"):
+		clip_path.use_interect_when_clipping = true
+		if clip_path.line:
+			clip_path.line.hide()
+		if clip_path.polygon:
+			clip_path.polygon.hide()
+		var applied_clip_path = clip_path.duplicate()
+		new_clip_paths.append(applied_clip_path)
 
-func add_stroke_to_path(new_path : ScalableVectorShape2D, style: Dictionary, scene_root : Node,
-			gradients : Array[Dictionary], gradient_point_parent : Node2D,
-			_image_texture : ImageTexture):
-	if style.has("stroke") and style["stroke"] != "none":
-		var stroke : Node2D = Line2D.new() if import_stroke_as_line_2d else Polygon2D.new()
-		var prop_name := "line" if import_stroke_as_line_2d else "poly_stroke"
-		stroke.name = "Stroke"
-		stroke.antialiased = antialiased_shapes
-		_managed_add_child_and_set_owner(new_path, stroke, scene_root, prop_name)
-		if style["stroke"].begins_with("url"):
-			if stroke is Line2D:
-				log_message("⚠️ Gradient stroke style not supported by Line2D: " + style["stroke"])
-			else:
-				var href : String = style["stroke"].replace("url(", "").replace(")", "")
-				var svg_gradient = get_gradient_by_href(href, gradients)
-				if svg_gradient.is_empty():
-					log_message("⚠️ Cannot find gradient for href=%s" % href, LogLevel.WARN)
-				else:
-					add_gradient_to_fill(new_path, svg_gradient, stroke, scene_root, gradients, gradient_point_parent)
-		elif style["stroke"].begins_with("rgba"):
-			var parts := _parse_svg_transform_params(style["stroke"].replace("rgba", ""))
-			new_path.stroke_color = Color.from_rgba8(parts[0], parts[1], parts[2], parts[3])
-		elif style["stroke"].begins_with("rgb"):
-			var parts := _parse_svg_transform_params(style["stroke"].replace("rgb", ""))
-			new_path.stroke_color = Color.from_rgba8(parts[0], parts[1], parts[2])
-		else:
-			new_path.stroke_color = Color(style["stroke"])
-		if style.has("stroke-width"):
-			new_path.stroke_width = float(style['stroke-width'])
-		else:
-			new_path.stroke_width = 1.0
-		if style.has("stroke-opacity"):
-			new_path.stroke_color.a = float(style["stroke-opacity"])
+	logger.call("Processing %d clip-paths for %s" % [new_clip_paths.size(), svs.name], LogLevel.DEBUG)
+	svs.clip_paths = new_clip_paths
+	return new_clip_paths
 
-		if style.has("stroke-linecap") and style["stroke-linecap"] in  STROKE_CAP_MAP:
-			new_path.end_cap_mode = STROKE_CAP_MAP[style["stroke-linecap"]]
-			new_path.begin_cap_mode = STROKE_CAP_MAP[style["stroke-linecap"]]
-		else:
-			new_path.end_cap_mode = Line2D.LINE_CAP_NONE
-			new_path.begin_cap_mode = Line2D.LINE_CAP_NONE
 
-		if style.has("stroke-linejoin") and style["stroke-linejoin"] in STROKE_JOINT_MAP:
-			new_path.line_joint_mode = STROKE_JOINT_MAP[style["stroke-linejoin"]]
-		else:
-			new_path.line_joint_mode = Line2D.LINE_JOINT_SHARP
+static func add_stroke_to_path(new_path : ScalableVectorShape2D, style: Dictionary,
+			gradients : Array[Dictionary], import_settings : Dictionary, gradient_point_parent : Node2D,
+			_image_texture : ImageTexture, logger : Callable) -> Node2D:
+	if !style.has("stroke") or style["stroke"] == "none": return null
+	
+	var stroke : Node2D = Line2D.new() if import_settings.get("import_stroke_as_line_2d", true) else Polygon2D.new()
+	stroke.name = "Stroke"
+	stroke.antialiased = import_settings.get("antialiased_shapes", false)
+	new_path.add_child(stroke)
+	if import_settings.get("import_stroke_as_line_2d", true):
+		new_path.line = stroke
+	else:
+		new_path.poly_stroke = stroke
+	if style["stroke"].begins_with("url"):
 		if stroke is Line2D:
-			if style.has("stroke-miterlimit"):
-				stroke.sharp_limit = float(style["stroke-miterlimit"])
-			else:
-				stroke.sharp_limit = 4.0 # svg default
-			if use_antialiased_line_2d:
-				stroke.texture = load("res://addons/curved_lines_2d/LumAlpha8.tex")
-				stroke.texture_mode = Line2D.LINE_TEXTURE_TILE
-				stroke.texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
-
-
-
-func add_fill_to_path(new_path : ScalableVectorShape2D, style: Dictionary, scene_root : Node,
-			gradients : Array[Dictionary], gradient_point_parent : Node2D,
-			image_texture : ImageTexture):
-
-	if image_texture or style.has("fill") and style["fill"] != "none":
-		var polygon := Polygon2D.new()
-		polygon.name = "Fill"
-		polygon.antialiased = antialiased_shapes
-		_managed_add_child_and_set_owner(new_path, polygon, scene_root, 'polygon')
-		if image_texture != null:
-			var box := new_path.get_bounding_rect()
-			polygon.texture = image_texture
-			polygon.texture_offset = -box.position
-			polygon.texture_scale = polygon.texture.get_size() / box.size
-		elif style["fill"].begins_with("url"):
-			var href : String = style["fill"].replace("url(", "").replace(")", "")
+			logger.call("⚠️ Gradient stroke style not supported by Line2D: " + style["stroke"], LogLevel.WARN)
+		else:
+			var href : String = style["stroke"].replace("url(", "").replace(")", "")
 			var svg_gradient = get_gradient_by_href(href, gradients)
 			if svg_gradient.is_empty():
-				log_message("⚠️ Cannot find gradient for href=%s" % href, LogLevel.WARN)
+				logger.call("⚠️ Cannot find gradient for href=%s" % href, LogLevel.WARN)
 			else:
-				add_gradient_to_fill(new_path, svg_gradient, polygon, scene_root, gradients, gradient_point_parent)
-		elif style["fill"].begins_with("rgba"):
-			var parts := _parse_svg_transform_params(style["fill"].replace("rgba", ""))
-			new_path.fill_color = Color.from_rgba8(parts[0], parts[1], parts[2], parts[3])
-		elif style["fill"].begins_with("rgb"):
-			var parts := _parse_svg_transform_params(style["fill"].replace("rgb", ""))
-			new_path.fill_color = Color.from_rgba8(parts[0], parts[1], parts[2])
+				add_gradient_to_fill(new_path, svg_gradient, stroke, gradients, gradient_point_parent)
+	elif style["stroke"].begins_with("rgba"):
+		var parts := _parse_svg_transform_params(style["stroke"].replace("rgba", ""))
+		new_path.stroke_color = Color.from_rgba8(parts[0], parts[1], parts[2], parts[3])
+	elif style["stroke"].begins_with("rgb"):
+		var parts := _parse_svg_transform_params(style["stroke"].replace("rgb", ""))
+		new_path.stroke_color = Color.from_rgba8(parts[0], parts[1], parts[2])
+	else:
+		new_path.stroke_color = Color(style["stroke"])
+	if style.has("stroke-width"):
+		new_path.stroke_width = float(style['stroke-width'])
+	else:
+		new_path.stroke_width = 1.0
+	if style.has("stroke-opacity"):
+		new_path.stroke_color.a = float(style["stroke-opacity"])
+
+	if style.has("stroke-linecap") and style["stroke-linecap"] in  STROKE_CAP_MAP:
+		new_path.end_cap_mode = STROKE_CAP_MAP[style["stroke-linecap"]]
+		new_path.begin_cap_mode = STROKE_CAP_MAP[style["stroke-linecap"]]
+	else:
+		new_path.end_cap_mode = Line2D.LINE_CAP_NONE
+		new_path.begin_cap_mode = Line2D.LINE_CAP_NONE
+
+	if style.has("stroke-linejoin") and style["stroke-linejoin"] in STROKE_JOINT_MAP:
+		new_path.line_joint_mode = STROKE_JOINT_MAP[style["stroke-linejoin"]]
+	else:
+		new_path.line_joint_mode = Line2D.LINE_JOINT_SHARP
+	if stroke is Line2D:
+		if style.has("stroke-miterlimit"):
+			stroke.sharp_limit = float(style["stroke-miterlimit"])
 		else:
-			new_path.fill_color = Color(style["fill"])
-			if style.has("fill-opacity"):
-				new_path.fill_color.a = float(style["fill-opacity"])
+			stroke.sharp_limit = 4.0 # svg default
+		if import_settings.get("use_antialiased_line_2d", false):
+			stroke.texture = load("res://addons/curved_lines_2d/LumAlpha8.tex")
+			stroke.texture_mode = Line2D.LINE_TEXTURE_TILE
+			stroke.texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
+	return stroke
 
 
-func add_collision_to_path(new_path : ScalableVectorShape2D, style : Dictionary, scene_root : Node,
-			_gradients : Array[Dictionary], _gradient_point_parent : Node2D,
-			_image_texture : ImageTexture) -> void:
-	if collision_object_type != ScalableVectorShape2D.CollisionObjectType.NONE:
-		match collision_object_type:
-			ScalableVectorShape2D.CollisionObjectType.STATIC_BODY_2D:
-				_managed_add_child_and_set_owner(new_path, StaticBody2D.new(), scene_root, 'collision_object')
-			ScalableVectorShape2D.CollisionObjectType.AREA_2D:
-				_managed_add_child_and_set_owner(new_path, Area2D.new(), scene_root, 'collision_object')
-			ScalableVectorShape2D.CollisionObjectType.ANIMATABLE_BODY_2D:
-				_managed_add_child_and_set_owner(new_path, AnimatableBody2D.new(), scene_root, 'collision_object')
-			ScalableVectorShape2D.CollisionObjectType.RIGID_BODY_2D:
-				_managed_add_child_and_set_owner(new_path, RigidBody2D.new(), scene_root, 'collision_object')
-			ScalableVectorShape2D.CollisionObjectType.CHARACTER_BODY_2D:
-				_managed_add_child_and_set_owner(new_path, CharacterBody2D.new(), scene_root, 'collision_object')
-			ScalableVectorShape2D.CollisionObjectType.PHYSICAL_BONE_2D:
-				_managed_add_child_and_set_owner(new_path, PhysicalBone2D.new(), scene_root, 'collision_object')
+
+static func add_fill_to_path(new_path : ScalableVectorShape2D, style: Dictionary,
+			gradients : Array[Dictionary], import_settings : Dictionary, gradient_point_parent : Node2D,
+			image_texture : ImageTexture, logger : Callable) -> Node2D:
+	if !image_texture and (!style.has("fill") or style["fill"] == "none"): return null
+	
+	var polygon := Polygon2D.new()
+	polygon.name = "Fill"
+	polygon.antialiased = import_settings.get("antialiased_shapes", false)
+	new_path.add_child(polygon)
+	new_path.polygon = polygon
+	if image_texture != null:
+		var box := new_path.get_bounding_rect()
+		polygon.texture = image_texture
+		polygon.texture_offset = -box.position
+		polygon.texture_scale = polygon.texture.get_size() / box.size
+	elif style["fill"].begins_with("url"):
+		var href : String = style["fill"].replace("url(", "").replace(")", "")
+		var svg_gradient = get_gradient_by_href(href, gradients)
+		if svg_gradient.is_empty():
+			logger.call("⚠️ Cannot find gradient for href=%s" % href, LogLevel.WARN)
+		else:
+			add_gradient_to_fill(new_path, svg_gradient, polygon, gradients, gradient_point_parent)
+	elif style["fill"].begins_with("rgba"):
+		var parts := _parse_svg_transform_params(style["fill"].replace("rgba", ""))
+		new_path.fill_color = Color.from_rgba8(parts[0], parts[1], parts[2], parts[3])
+	elif style["fill"].begins_with("rgb"):
+		var parts := _parse_svg_transform_params(style["fill"].replace("rgb", ""))
+		new_path.fill_color = Color.from_rgba8(parts[0], parts[1], parts[2])
+	else:
+		new_path.fill_color = Color(style["fill"])
+		if style.has("fill-opacity"):
+			new_path.fill_color.a = float(style["fill-opacity"])
+	return polygon
 
 
-func add_gradient_to_fill(new_path : ScalableVectorShape2D, svg_gradient: Dictionary, polygon : Polygon2D,
-		scene_root : Node, gradients : Array[Dictionary], gradient_point_parent : Node2D) -> void:
+static func add_collision_to_path(new_path : ScalableVectorShape2D, style : Dictionary,
+			_gradients : Array[Dictionary], import_settings : Dictionary, _gradient_point_parent : Node2D,
+			_image_texture : ImageTexture, logger : Callable) -> Node2D:
+	match import_settings.get("collision_object_type",ScalableVectorShape2D.CollisionObjectType.NONE):
+		ScalableVectorShape2D.CollisionObjectType.STATIC_BODY_2D:
+			return StaticBody2D.new()
+		ScalableVectorShape2D.CollisionObjectType.AREA_2D:
+			return Area2D.new()
+		ScalableVectorShape2D.CollisionObjectType.ANIMATABLE_BODY_2D:
+			return AnimatableBody2D.new()
+		ScalableVectorShape2D.CollisionObjectType.RIGID_BODY_2D:
+			return RigidBody2D.new()
+		ScalableVectorShape2D.CollisionObjectType.CHARACTER_BODY_2D:
+			return CharacterBody2D.new()
+		ScalableVectorShape2D.CollisionObjectType.PHYSICAL_BONE_2D:
+			return PhysicalBone2D.new()
+	return null
+
+
+static func add_gradient_to_fill(new_path : ScalableVectorShape2D, svg_gradient: Dictionary, polygon : Polygon2D,
+		 gradients : Array[Dictionary], gradient_point_parent : Node2D) -> void:
 	if "xlink:href" in svg_gradient:
 		svg_gradient.merge(get_gradient_by_href(svg_gradient["xlink:href"], gradients), false)
 	elif "href" in svg_gradient:
@@ -803,7 +772,7 @@ func add_gradient_to_fill(new_path : ScalableVectorShape2D, svg_gradient: Dictio
 		)
 		var fill_from = Vector2(float(svg_gradient["cx"]), float(svg_gradient["cy"]))
 		var fill_to = fill_from + Vector2.RIGHT * float(svg_gradient["r"])
-		apply_gradient(new_path, svg_gradient, polygon, scene_root, gradients, gradient_point_parent,
+		apply_gradient(new_path, svg_gradient, polygon, gradients, gradient_point_parent,
 				box, texture, fill_from, fill_to, gradient_transform)
 		texture.fill = GradientTexture2D.FILL_RADIAL
 	elif "x1" in svg_gradient and "y1" in svg_gradient and "x2" in svg_gradient and "y2" in svg_gradient:
@@ -813,20 +782,20 @@ func add_gradient_to_fill(new_path : ScalableVectorShape2D, svg_gradient: Dictio
 		)
 		var fill_from = Vector2(float(svg_gradient["x1"]), float(svg_gradient["y1"]))
 		var fill_to = Vector2(float(svg_gradient["x2"]), float(svg_gradient["y2"]))
-		apply_gradient(new_path, svg_gradient, polygon, scene_root, gradients, gradient_point_parent,
+		apply_gradient(new_path, svg_gradient, polygon, gradients, gradient_point_parent,
 				box, texture, fill_from, fill_to, gradient_transform)
 	polygon.texture_offset = -box.position
 	polygon.texture = texture
 
 
-func apply_gradient(new_path : ScalableVectorShape2D, svg_gradient: Dictionary, polygon : Polygon2D,
-		scene_root : Node, gradients : Array[Dictionary], gradient_point_parent : Node2D, box : Rect2,
+static func apply_gradient(new_path : ScalableVectorShape2D, svg_gradient: Dictionary, polygon : Polygon2D, 
+		gradients : Array[Dictionary], gradient_point_parent : Node2D, box : Rect2,
 		texture : GradientTexture2D, fill_from : Vector2, fill_to : Vector2, gradient_transform : Transform2D) -> void:
-	var gradient_transform_node = create_helper_node("Gradient(%s)" % new_path.name, gradient_point_parent, scene_root, Vector2.ZERO, gradient_transform)
-	var from_node = create_helper_node("From(%s)" % new_path.name, gradient_transform_node, scene_root, fill_from)
-	var to_node = create_helper_node("To(%s)" % new_path.name, gradient_transform_node, scene_root, fill_to)
-	var box_tl_node = create_helper_node("BoxTopLeft(%s)" % new_path.name, gradient_point_parent, scene_root, new_path.position + box.position)
-	var box_br_node = create_helper_node("BoxBottomRight(%s)" % new_path.name, gradient_point_parent, scene_root, box_tl_node.position + box.size)
+	var gradient_transform_node = create_helper_node("Gradient(%s)" % new_path.name, gradient_point_parent, Vector2.ZERO, gradient_transform)
+	var from_node = create_helper_node("From(%s)" % new_path.name, gradient_transform_node, fill_from)
+	var to_node = create_helper_node("To(%s)" % new_path.name, gradient_transform_node, fill_to)
+	var box_tl_node = create_helper_node("BoxTopLeft(%s)" % new_path.name, gradient_point_parent, new_path.position + box.position)
+	var box_br_node = create_helper_node("BoxBottomRight(%s)" % new_path.name, gradient_point_parent, box_tl_node.position + box.size)
 	texture.fill_from = (from_node.global_position - box_tl_node.global_position) / (box_br_node.global_position - box_tl_node.global_position)
 	texture.fill_to = (to_node.global_position - box_tl_node.global_position) / (box_br_node.global_position - box_tl_node.global_position)
 	gradient_transform_node.queue_free()
@@ -834,12 +803,11 @@ func apply_gradient(new_path : ScalableVectorShape2D, svg_gradient: Dictionary, 
 	box_br_node.queue_free()
 
 
-func create_helper_node(node_name : String, node_parent : Node2D, node_owner : Node,
+static func create_helper_node(node_name : String, node_parent : Node2D,
 		node_position := Vector2.ZERO, node_transform := Transform2D.IDENTITY) -> Node2D:
 	var helper_node := Node2D.new()
 	helper_node.name = node_name
 	node_parent.add_child(helper_node, true)
-	helper_node.set_owner(node_owner)
 	if node_position != Vector2.ZERO:
 		helper_node.position = node_position
 	if node_transform != Transform2D.IDENTITY:
@@ -847,20 +815,20 @@ func create_helper_node(node_name : String, node_parent : Node2D, node_owner : N
 	return helper_node
 
 
-func get_svg_transform(element:SVGXMLElement) -> Transform2D:
+static func get_svg_transform(element:SVGXMLElement) -> Transform2D:
 	if element.has_attribute("transform"):
 		return process_svg_transform(element.get_named_attribute_value("transform"))
 	else:
 		return Transform2D.IDENTITY
 
 
-func _parse_svg_transform_params(svg_transform_params : String) -> PackedFloat64Array:
+static func _parse_svg_transform_params(svg_transform_params : String) -> PackedFloat64Array:
 	return (svg_transform_params
 		.replace("(", "").replace(")", "").replace(",", " ")
 		.split_floats(" ", false))
 
 
-func process_svg_transform(svg_transform_attr : String) -> Transform2D:
+static func process_svg_transform(svg_transform_attr : String) -> Transform2D:
 	var svg_commands = (
 			Array(svg_transform_attr.split(")", false))
 					.map(func(cmd): return cmd.lstrip(" \t\r\n") + ")")
@@ -898,21 +866,6 @@ func process_svg_transform(svg_transform_attr : String) -> Transform2D:
 				transform[i] = Vector2(matrix[i*2], matrix[i*2+1])
 	return transform
 
-
-func _managed_add_child_and_set_owner(parent : Node, child : Node,
-		scene_root : Node, as_property := ""):
-	if not child.get_parent() == parent:
-		parent.add_child(child, true)
-	child.set_owner(scene_root)
-	undo_redo.add_do_method(parent, 'add_child', child, true)
-	undo_redo.add_do_method(child, 'set_owner', scene_root)
-	undo_redo.add_do_reference(child)
-	undo_redo.add_undo_method(parent, 'remove_child', child)
-	if not as_property.is_empty():
-		parent.call("set", as_property, child)
-		undo_redo.add_do_property(parent, as_property, child)
-
-
 static func parse_attribute_string(raw_attribute_str : String) -> String:
 	var regex = RegEx.new()
 	regex.compile("\\S+")
@@ -920,48 +873,3 @@ static func parse_attribute_string(raw_attribute_str : String) -> String:
 	for result  in regex.search_all(raw_attribute_str):
 		str_path += result.get_string() + " "
 	return str_path.strip_edges()
-
-
-class UndoRedoHandler:
-	func add_do_method(thing : Object, meth : String,
-				arg0 : Variant = null, arg1 : Variant = null, arg2 : Variant = null, arg3 : Variant = null) -> void:
-		if meth == "add_child" and thing == (arg0 as Node).get_parent():
-			return
-		if arg3 != null:
-			thing.callv(meth, [arg0, arg1, arg2, arg3])
-		elif arg2 != null:
-			thing.callv(meth, [arg0, arg1, arg2])
-		elif arg1 != null:
-			thing.callv(meth, [arg0, arg1])
-		elif arg0 != null:
-			thing.callv(meth, [arg0])
-		else:
-			thing.call(meth)
-
-
-	func add_undo_method(_thing : Object, _meth : String,
-				arg0 : Variant = null, arg1 : Variant = null, arg2 : Variant = null, arg3 : Variant = null) -> void:
-		pass
-
-
-	func add_do_property(thing : Object, prop_name : String, prop_value : Variant) -> void:
-		thing[prop_name] = prop_value
-
-
-	func add_undo_property(_thing : Object, _prop_name : String, _prop_value : Variant) -> void:
-		pass
-
-
-	func add_do_reference(_thing : Object) -> void:
-		pass
-
-
-	func create_action(action_name : String) -> void:
-		pass
-
-	func commit_action(_apply : bool) -> void:
-		pass
-
-
-static func get_runtime_handler() -> UndoRedoHandler:
-	return UndoRedoHandler.new()

--- a/addons/curved_lines_2d/svg_xml_element.gd
+++ b/addons/curved_lines_2d/svg_xml_element.gd
@@ -12,10 +12,9 @@ var attributes : Dictionary[String, String]
 var children : Array[SVGXMLElement]
 var parent : SVGXMLElement
 
-func _init(xml_parser : XMLParser, with_parent : SVGXMLElement = null):
-	name = xml_parser.get_node_name()
-	for i in xml_parser.get_attribute_count():
-		attributes[xml_parser.get_attribute_name(i)] = xml_parser.get_attribute_value(i)
+func _init(name : String, attributes : Dictionary[String, String], with_parent : SVGXMLElement = null):
+	self.name = name
+	self.attributes = attributes
 	parent = with_parent
 
 func add_child(ch : SVGXMLElement) -> void:


### PR DESCRIPTION
This pull request aims to improve the readability and maintianability of `SVGImporter` by doing a few things:

1. Making all class functions static. This should aid in testing and modularity. It also removes lines of code for the consumer, since they no longer have to make an instance.
2. Moving all import options to a dictionary. This means that the import options are labeled for the user. It also means that the user only has to specify those options that matter to her - the order of the defaults no longer matters.
3. Removing the requirement that the svg immediately be put into the scene. `load_svg` no longer requires access to the scene root or a parent node. It instead simply gives you a node.

Additionally

- `XMLElement` no longer requires an `XMLPaser`, which is helpful for testing

 ### Downsides

-  Ownership is no longer assigned, since the root node is no longer known. The ownership is now assigned when imported after the fact
- `PAINT_ORDER_MAP` can no longer be cached; `call` is an instance method, and `Callable` cannot be static. In future Godot versions, [this may be possible](https://github.com/godotengine/godot-proposals/issues/11275), but given backwards compatibility... `PAINT_ORDER_MAP` has been moved into the function where it is used. This may have a performance impact.
- I have no idea how to test for regressions

## Acknowledgement of Absurdity
This is a massive refactor - I don't expect this to get merged quickly or maybe at all. This is useful for me, and I had fun doing it. (I love refactoring.) 