### PR TITLE
Allows Line2D to use color provided by Inkscape swatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 
-## 2.33.2
+## 2.33.3
 
 ### Added
 
 - Import SVG files as nodes at runtime
 - ScalableVectorShape2D now also handles `assigned_node_changed` signal at runtime
+- Support for colors set by `inkscape:swatch` on strokes (thanks @claire-aware)
 
 ### Changed 
 
 - Bugfix 4.8-dev4: new localizer for 2D editor buttons control
 - Bugfix: fixes editor crash once every indeterminate of times when releasing mouse over `ScalableVectorShape2D` bounding box while dragging when another node is selected - also selection now remains on selected node. 
+- Bugfix: SVG Import without `ScalableVectorShape2D` now supports undo/redo
+
 
 ## 2.32.0 - Redemption
 

--- a/addons/curved_lines_2d/plugin.cfg
+++ b/addons/curved_lines_2d/plugin.cfg
@@ -2,6 +2,6 @@
 
 name="Scalable Vector Shapes 2D"
 description="This plugin and SVG importer helps you draw 2D scalable vector shapes as Godot nodes directly in the 2D viewport."
-author="René van der Ark, Mark Hedberg, Thiago Lages de Alencar and @kcfresh53"
-version="2.33.2"
+author="René van der Ark, Mark Hedberg, Thiago Lages de Alencar, @kcfresh53 and [TODO: your name/handle/nothing? here]"
+version="2.33.3"
 script="curved_lines_2d.gd"

--- a/addons/curved_lines_2d/plugin.cfg
+++ b/addons/curved_lines_2d/plugin.cfg
@@ -2,6 +2,6 @@
 
 name="Scalable Vector Shapes 2D"
 description="This plugin and SVG importer helps you draw 2D scalable vector shapes as Godot nodes directly in the 2D viewport."
-author="René van der Ark, Mark Hedberg, Thiago Lages de Alencar, @kcfresh53 and [TODO: your name/handle/nothing? here]"
+author="René van der Ark, Mark Hedberg, Thiago Lages de Alencar, @kcfresh53, and Claire Woods"
 version="2.33.3"
 script="curved_lines_2d.gd"

--- a/addons/curved_lines_2d/svg_importer.gd
+++ b/addons/curved_lines_2d/svg_importer.gd
@@ -675,15 +675,23 @@ func add_stroke_to_path(new_path : ScalableVectorShape2D, style: Dictionary, sce
 		stroke.antialiased = antialiased_shapes
 		_managed_add_child_and_set_owner(new_path, stroke, scene_root, prop_name)
 		if style["stroke"].begins_with("url"):
+			var href : String = style["stroke"].replace("url(", "").replace(")", "")
+			var svg_gradient = get_gradient_by_href(href, gradients)
+			if svg_gradient.is_empty():
+				log_message("⚠️ Cannot find gradient for href=%s" % href, LogLevel.WARN)
+			var gradiant_data
+			if "xlink:href" in svg_gradient:
+				gradiant_data = get_gradient_by_href(svg_gradient["xlink:href"], gradients)
+			elif "href" in svg_gradient:
+				gradiant_data = get_gradient_by_href(svg_gradient["href"], gradients)
 			if stroke is Line2D:
-				log_message("⚠️ Gradient stroke style not supported by Line2D: " + style["stroke"])
+				if !gradiant_data.has("inkscape:swatch"):
+					log_message("⚠️ Gradient stroke style not supported by Line2D: " + style["stroke"])
+				else: 
+					new_path.stroke_color = Color(gradiant_data["stops"][0]["style"]["stop-color"],
+					float(gradiant_data["stops"][0]["style"]["stop-opacity"]))
 			else:
-				var href : String = style["stroke"].replace("url(", "").replace(")", "")
-				var svg_gradient = get_gradient_by_href(href, gradients)
-				if svg_gradient.is_empty():
-					log_message("⚠️ Cannot find gradient for href=%s" % href, LogLevel.WARN)
-				else:
-					add_gradient_to_fill(new_path, svg_gradient, stroke, scene_root, gradients, gradient_point_parent)
+				add_gradient_to_fill(new_path, svg_gradient, stroke, scene_root, gradients, gradient_point_parent)
 		elif style["stroke"].begins_with("rgba"):
 			var parts := _parse_svg_transform_params(style["stroke"].replace("rgba", ""))
 			new_path.stroke_color = Color.from_rgba8(parts[0], parts[1], parts[2], parts[3])

--- a/addons/curved_lines_2d/svg_importer.gd
+++ b/addons/curved_lines_2d/svg_importer.gd
@@ -694,17 +694,18 @@ func add_stroke_to_path(new_path : ScalableVectorShape2D, style: Dictionary, sce
 			var svg_gradient = get_gradient_by_href(href, gradients)
 			if svg_gradient.is_empty():
 				log_message("⚠️ Cannot find gradient for href=%s" % href, LogLevel.WARN)
-			var gradiant_data
+			var gradient_data := {}
 			if "xlink:href" in svg_gradient:
-				gradiant_data = get_gradient_by_href(svg_gradient["xlink:href"], gradients)
+				gradient_data = get_gradient_by_href(svg_gradient["xlink:href"], gradients)
 			elif "href" in svg_gradient:
-				gradiant_data = get_gradient_by_href(svg_gradient["href"], gradients)
+				gradient_data = get_gradient_by_href(svg_gradient["href"], gradients)
 			if stroke is Line2D:
-				if !gradiant_data.has("inkscape:swatch"):
+				if !gradient_data.has("inkscape:swatch"):
 					log_message("⚠️ Gradient stroke style not supported by Line2D: " + style["stroke"])
-				else: 
-					new_path.stroke_color = Color(gradiant_data["stops"][0]["style"]["stop-color"],
-					float(gradiant_data["stops"][0]["style"]["stop-opacity"]))
+				else:
+					new_path.stroke_color = Color(gradient_data["stops"][0]["style"]["stop-color"],
+							float(gradient_data["stops"][0]["style"]["stop-opacity"])
+					)
 			else:
 				add_gradient_to_fill(new_path, svg_gradient, stroke, scene_root, gradients, gradient_point_parent)
 		elif style["stroke"].begins_with("rgba"):


### PR DESCRIPTION
Simply removes an edge case where a color is a liner gradient under the hood, but not for the user.