### PR TITLE
fixes #431 ScalableVectorShape2D is not clickable to select when an a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## 2.34.0 - SyncSkape
+## 2.34.1 - SyncSkape
 
 ### Added
 
@@ -10,6 +10,9 @@
 - A new opt-in flag to import svg `<g>`-groups as an edit group as well as `ScalableVectorShape2D` 
 - Support for inkscape based pivot points mapped from the `inkscape:transform-center-{xy}` attribute
 
+### Changed
+
+- fix: `ScalableVectorShape2D` that is a descendant of a node with `"_edit_group_"` toggled on is not selected on click anymore.
 
 ## 2.33.3
 

--- a/addons/curved_lines_2d/curved_lines_2d.gd
+++ b/addons/curved_lines_2d/curved_lines_2d.gd
@@ -604,6 +604,7 @@ func _find_scalable_vector_shape_2d_nodes_at(pos : Vector2) -> Array[Node]:
 	if is_instance_valid(EditorInterface.get_edited_scene_root()):
 		return (_find_scalable_vector_shape_2d_nodes()
 					.filter(func(x : ScalableVectorShape2D): return not x.has_meta("_edit_lock_"))
+					.filter(func(x : ScalableVectorShape2D): return not _is_inside_edit_group(x))
 					.filter(func(x : ScalableVectorShape2D): return x.is_visible_in_tree())
 					.filter(func(x : ScalableVectorShape2D): return x.owner == EditorInterface.get_edited_scene_root())
 					.filter(func(x : ScalableVectorShape2D): return x.has_point(_svp_mouse_pos(pos, x)))
@@ -941,6 +942,17 @@ func _svp_mouse_pos(pos : Vector2, n : Node) -> Vector2:
 			return (n as SubViewport).get_mouse_position()
 		n = n.get_parent()
 	return pos
+
+
+func _is_inside_edit_group(svs : ScalableVectorShape2D) -> bool:
+	if svs == EditorInterface.get_edited_scene_root():
+		return false
+	var n := svs.get_parent()
+	while is_instance_valid(n) and not n == EditorInterface.get_edited_scene_root():
+		if n.has_meta("_edit_group_"):
+			return true
+		n = n.get_parent()
+	return false
 
 
 func _set_handle_hover(g_mouse_pos : Vector2, svs : ScalableVectorShape2D) -> void:

--- a/addons/curved_lines_2d/plugin.cfg
+++ b/addons/curved_lines_2d/plugin.cfg
@@ -3,5 +3,5 @@
 name="Scalable Vector Shapes 2D"
 description="This plugin and SVG importer helps you draw 2D scalable vector shapes as Godot nodes directly in the 2D viewport."
 author="René van der Ark, Mark Hedberg, Thiago Lages de Alencar, @kcfresh53, and Claire Woods"
-version="2.34.0"
+version="2.34.1"
 script="curved_lines_2d.gd"


### PR DESCRIPTION
…ncestor node marks an edit_group.