### PR TITLE
439 group pivot incorrect when scaledsvgroot has scale before import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ addons/DualEditor
 .vscode
 export_presets.cfg
 /*.svg*
+*.png
+*.png*
+*.tscn
+*.gd*
+*.jpg*
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,3 @@ addons/DualEditor
 .vscode
 export_presets.cfg
 /*.svg*
-*.png
-*.png*
-*.tscn
-*.gd*
-*.jpg*
-.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## 2.34.3 - Inkscape Sync
+## 2.34.4 - Inkscape Sync
 
 ### Added
 
@@ -16,6 +16,7 @@
 - fix: `ScalableVectorShape2D` that is a descendant of a node with `"_edit_group_"` toggled on is not selected on click anymore.
 - bugfix: Makes clip paths for holes connect signals correctly again after svg import
 - editor performance fix: replace all instances of using node metadata to store hover state with editor plugin variables
+- bugfix: when SyncedSVGRoot has a different scale / rotation, pivots are now placed correctly during reimport
 
 ## 2.33.3
 

--- a/addons/curved_lines_2d/curved_lines_2d.gd
+++ b/addons/curved_lines_2d/curved_lines_2d.gd
@@ -3041,6 +3041,8 @@ func _reimport_synchronized_svg_file(svg_root : SyncedSVGRoot) -> void:
 		return
 	if svg_root.has_meta("is_importing"):
 		return
+	var stored_global_transform = svg_root.global_transform
+	svg_root.global_transform = Transform2D.IDENTITY
 	svg_root.set_meta("is_importing", true)
 	svg_root.set_meta("_checksum", new_checksum)
 	if is_instance_valid(ch):
@@ -3049,6 +3051,7 @@ func _reimport_synchronized_svg_file(svg_root : SyncedSVGRoot) -> void:
 			SVGImporter.get_runtime_handler(), _pretty_print_svg_import_msg)
 	await svg_importer.load_svg(svg_root.svg_resource_path,
 			scene_root, [svg_root])
+	svg_root.global_transform = stored_global_transform
 	svg_root.remove_meta("is_importing")
 	svg_root.update_configuration_warnings()
 	EditorInterface.mark_scene_as_unsaved()

--- a/addons/curved_lines_2d/plugin.cfg
+++ b/addons/curved_lines_2d/plugin.cfg
@@ -3,5 +3,5 @@
 name="Scalable Vector Shapes 2D"
 description="This plugin and SVG importer helps you draw 2D scalable vector shapes as Godot nodes directly in the 2D viewport."
 author="René van der Ark, Mark Hedberg, Thiago Lages de Alencar, @kcfresh53, and Claire Woods"
-version="2.34.3"
+version="2.34.4"
 script="curved_lines_2d.gd"


### PR DESCRIPTION
@claire-aware , I used my original plan (to remember `global_transform`, reset `global_transform`, reimport and then restore to the remembered `global_transform`) 

This is visible during reimport for one frame, but that shouldn't impact anything else. 

Could you please review? 